### PR TITLE
Refactoring namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,25 @@
 
 # AWS Croniter
 
-AWS Croniter is a Python library that provides utilities for working with AWS cron expressions. It allows you to easily
-parse, manipulate, and validate cron expressions used in AWS services like CloudWatch and EventBridge.
+AWS Croniter is a Python package for parsing, validating, and calculating occurrences of AWS EventBridge cron
+expressions. AWS cron expressions are a powerful way to schedule events, but they differ from standard Unix cron syntax.
+This library makes it easy to work with AWS-specific cron schedules programmatically.
 
 ## Features
 
-- Parse AWS cron expressions
-- Validate cron expressions
-- Generate next execution times
-- Convert cron expressions to human-readable format
+- Validate AWS cron expressions against AWS EventBridge syntax.
+- Parse and interpret cron rules with detailed validation error messages.
+- Compute:
+    - Next and previous occurrence times for a given schedule.
+    - All occurrences of a schedule between two given dates.
+- Handle special AWS cron syntax (e.g., `?`, `L`, `W`, `#`) and aliases for months (`JAN`, `FEB`, ...) and days of the
+  week (`SUN`, `MON`, ...).
 
 ## Installation
 
-You can install AWS Croniter using pip:
+Install the package via pip:
 
-```sh
+```bash
 pip install aws-croniter
 ```
 
@@ -28,22 +32,77 @@ pip install aws-croniter
 Here is a basic example of how to use AWS Croniter:
 
 ```python
-from aws_croniter import Croniter
+from aws_cronite import AwsCroniter
 
-# Create a Croniter object with an AWS cron expression
-cron = Croniter('cron(0 12 * * ? *)')
+# Example AWS cron expression
+cron_expression = "0 12 15 * ? 2023"
 
-# Validate the cron expression
-if cron.is_valid():
-    print("The cron expression is valid.")
+aws_cron = AwsCroniter(cron_expression)
+```
 
-# Get the next execution time
-next_time = cron.get_next()
-print(f"The next execution time is: {next_time}")
+Getting the Next Occurrence
 
-# Convert to human-readable format
-human_readable = cron.to_human_readable()
-print(f"Human-readable format: {human_readable}")
+```python
+from aws_cronite import AwsCroniter
+from datetime import datetime, timezone
+
+# Example AWS cron expression
+cron_expression = "0 12 15 * ? 2023"
+aws_cron = AwsCroniter(cron_expression)
+# Start from a given datetime
+start_date = datetime(2023, 12, 14, tzinfo=timezone.utc)
+next_occurrence = aws_cron.get_next(start_date)
+
+print(next_occurrence)
+## Results in [datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc)]
+```
+
+Getting the Previous Occurrence
+
+```python
+from aws_cronite import AwsCroniter
+from datetime import datetime, timezone
+
+# Example AWS cron expression
+cron_expression = "0 12 15 * ? 2023"
+aws_cron = AwsCroniter(cron_expression)
+# Start from a given datetime
+start_date = datetime(2023, 12, 14, tzinfo=timezone.utc)
+prev_occurrence = aws_cron.get_prev(start_date)
+
+print(prev_occurrence)
+```
+
+Getting All Occurrences Between Two Dates
+
+```python
+from aws_cronite import AwsCroniter
+from datetime import datetime, timezone
+
+# Example AWS cron expression
+cron_expression = "0 12 15 * ? 2023"
+
+aws_cron = AwsCroniter(cron_expression)
+from_date = datetime(2023, 12, 14, tzinfo=timezone.utc)
+to_date = datetime(2023, 12, 31, tzinfo=timezone.utc)
+
+all_occurrences = aws_cron.get_all_schedule_bw_dates(from_date, to_date)
+
+print(all_occurrences)
+```
+
+Handling Validation Errors
+
+If an invalid AWS cron expression is provided, AwsCroniter raises specific exceptions indicating the type of error:
+
+```python
+from aws_cronite.exceptions import AwsCroniterExpressionError
+
+try:
+    invalid_cron = "0 18 ? * MON-FRI"  # Missing required fields
+    AwsCroniter(invalid_cron)
+except AwsCroniterExpressionError as e:
+    print(f"Invalid cron expression: {e}")
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install aws-croniter
 Here is a basic example of how to use AWS Croniter:
 
 ```python
-from aws_cronite import AwsCroniter
+from aws_croniter import AwsCroniter
 
 # Example AWS cron expression
 cron_expression = "0 12 15 * ? 2023"
@@ -43,7 +43,7 @@ aws_cron = AwsCroniter(cron_expression)
 Getting the Next Occurrence
 
 ```python
-from aws_cronite import AwsCroniter
+from aws_croniter import AwsCroniter
 from datetime import datetime, timezone
 
 # Example AWS cron expression
@@ -54,13 +54,13 @@ start_date = datetime(2023, 12, 14, tzinfo=timezone.utc)
 next_occurrence = aws_cron.get_next(start_date)
 
 print(next_occurrence)
-## Results in [datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc)]
+## Results in: [datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc)]
 ```
 
 Getting the Previous Occurrence
 
 ```python
-from aws_cronite import AwsCroniter
+from aws_croniter import AwsCroniter
 from datetime import datetime, timezone
 
 # Example AWS cron expression
@@ -71,24 +71,26 @@ start_date = datetime(2023, 12, 14, tzinfo=timezone.utc)
 prev_occurrence = aws_cron.get_prev(start_date)
 
 print(prev_occurrence)
+## Results in: [datetime.datetime(2023, 11, 15, 12, 0, tzinfo=datetime.timezone.utc)]
 ```
 
 Getting All Occurrences Between Two Dates
 
 ```python
-from aws_cronite import AwsCroniter
+from aws_croniter import AwsCroniter
 from datetime import datetime, timezone
 
 # Example AWS cron expression
 cron_expression = "0 12 15 * ? 2023"
 
 aws_cron = AwsCroniter(cron_expression)
-from_date = datetime(2023, 12, 14, tzinfo=timezone.utc)
+from_date = datetime(2023, 11, 14, tzinfo=timezone.utc)
 to_date = datetime(2023, 12, 31, tzinfo=timezone.utc)
 
 all_occurrences = aws_cron.get_all_schedule_bw_dates(from_date, to_date)
 
 print(all_occurrences)
+## Results in: [datetime.datetime(2023, 11, 15, 12, 0, tzinfo=datetime.timezone.utc), datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc)]
 ```
 
 Handling Validation Errors
@@ -96,13 +98,15 @@ Handling Validation Errors
 If an invalid AWS cron expression is provided, AwsCroniter raises specific exceptions indicating the type of error:
 
 ```python
-from aws_cronite.exceptions import AwsCroniterExpressionError
+from aws_croniter import AwsCroniter
+from aws_croniter.exceptions import AwsCroniterExpressionError
 
 try:
     invalid_cron = "0 18 ? * MON-FRI"  # Missing required fields
     AwsCroniter(invalid_cron)
 except AwsCroniterExpressionError as e:
     print(f"Invalid cron expression: {e}")
+## Results in: Invalid cron expression: Incorrect number of values in '0 18 ? * MON-FRI'. 6 required, 5 provided.
 ```
 
 ## Contributing

--- a/src/aws_croniter/__init__.py
+++ b/src/aws_croniter/__init__.py
@@ -1,0 +1,4 @@
+from .aws_croniter import AwsCroniter
+
+# Should be exported when using `from aws_croniter import *`
+__all__ = ["AwsCroniter"]

--- a/src/aws_croniter/aws_croniter.py
+++ b/src/aws_croniter/aws_croniter.py
@@ -169,63 +169,57 @@ class AwsCroniter:
         allows.sort()
         return allows
 
-    @staticmethod
-    def get_next_n_schedule(n, from_date, cron):
+    def get_next(self, from_date, n=1, inclusive=False):
         """
         Returns a list with the n next datetime(s) that match the aws cron expression from the provided start date.
 
-        :param n: Int of the n next datetime(s)
         :param from_date: datetime with the start date
-        :param cron: str of aws cron to be parsed
+        :param n: Int of the n next datetime(s), defaults to 1
+        :param inclusive: If True, include the from_date time if it matches a valid execution.
         :return: list of datetime objects
         """
-        schedule_list = list()
         if not isinstance(from_date, datetime.datetime):
             raise ValueError(
-                "Invalid from_date. Must be of type datetime.datetime" " and have tzinfo = datetime.timezone.utc"
+                "Invalid from_date. Must be of type datetime.datetime and have tzinfo = datetime.timezone.utc"
             )
         else:
-            cron_iterator = AwsCroniter(cron)
+            schedule_list = list()
             for i in range(n):
-                from_date = cron_iterator.occurrence(from_date).next()
+                from_date = self.occurrence(from_date).next(inclusive=(inclusive and i == 0))
                 schedule_list.append(from_date)
 
             return schedule_list
 
-    @staticmethod
-    def get_prev_n_schedule(n, from_date, cron):
+    def get_prev(self, from_date, n=1, inclusive=False):
         """
         Returns a list with the n prev datetime(s) that match the aws cron expression
         from the provided start date.
 
-        :param n: Int of the n next datetime(s)
         :param from_date: datetime with the start date
-        :param cron: str of aws cron to be parsed
+        :param n: Int of the n next datetime(s), defaults to 1
+        :param inclusive: If True, include the from_date time if it matches a valid execution.
         :return: list of datetime objects
         """
-        schedule_list = list()
         if not isinstance(from_date, datetime.datetime):
             raise ValueError(
                 "Invalid from_date. Must be of type datetime.datetime" " and have tzinfo = datetime.timezone.utc"
             )
         else:
-            cron_iterator = AwsCroniter(cron)
+            schedule_list = list()
             for i in range(n):
-                from_date = cron_iterator.occurrence(from_date).prev()
+                from_date = self.occurrence(from_date).prev(inclusive=(inclusive and i == 0))
                 schedule_list.append(from_date)
 
             return schedule_list
 
-    @staticmethod
-    def get_all_schedule_bw_dates(from_date, to_date, cron, exclude_ends=False):
+    def get_all_schedule_bw_dates(self, from_date, to_date, exclude_ends=False):
         """
-        Get all datetimes from from_date to to_date matching the given cron expression.
+        Get all datetime(s) from from_date to to_date matching the given cron expression.
         If the cron expression matches either 'from_date' and/or 'to_date',
         those times will be returned as well unless 'exclude_ends=True' is passed.
 
         :param from_date: datetime object from where the schedule will start with tzinfo in utc.
         :param to_date: datetime object to where the schedule will end with tzinfo in utc.
-        :param cron: str of aws cron to be parsed
         :param exclude_ends: bool defaulted to False, to not exclude the end date
         :return: list of datetime objects
         """
@@ -244,12 +238,11 @@ class AwsCroniter:
             )
         else:
             schedule_list = []
-            cron_iterator = AwsCroniter(cron)
             start = from_date.replace(second=0, microsecond=0) - datetime.timedelta(seconds=1)
             stop = to_date.replace(second=0, microsecond=0)
 
             while start is not None and start <= stop:
-                start = cron_iterator.occurrence(start).next()
+                start = self.occurrence(start).next()
                 if start is None or start > stop:
                     break
                 schedule_list.append(start)

--- a/src/aws_croniter/aws_croniter.py
+++ b/src/aws_croniter/aws_croniter.py
@@ -99,9 +99,6 @@ class AwsCroniter:
             raise Exception("Occurrence utc_datetime must have tzinfo == datetime.timezone.utc")
         return Occurrence(self, utc_datetime)
 
-    def __str__(self):
-        return f"cron({self.cron})"
-
     def __replace(self, s, rules):
         rs = str(s).upper()
         for rule in rules:
@@ -202,7 +199,7 @@ class AwsCroniter:
         """
         if not isinstance(from_date, datetime.datetime):
             raise ValueError(
-                "Invalid from_date. Must be of type datetime.datetime" " and have tzinfo = datetime.timezone.utc"
+                "Invalid from_date. Must be of type datetime.datetime and have tzinfo = datetime.timezone.utc"
             )
         else:
             schedule_list = list()
@@ -228,13 +225,13 @@ class AwsCroniter:
             isinstance(from_date, type(to_date)) or isinstance(to_date, type(from_date))
         ):
             raise ValueError(
-                "The from_date and to_date must be same type." "  {0} != {1}".format(type(from_date), type(to_date))
+                "The from_date and to_date must be same type. {0} != {1}".format(type(from_date), type(to_date))
             )
 
         elif not isinstance(from_date, datetime.datetime) or (from_date.tzinfo != datetime.timezone.utc):
             raise ValueError(
-                "Invalid from_date and to_date. Must be of type datetime.datetime"
-                " and have tzinfo = datetime.timezone.utc"
+                "Invalid from_date and to_date. Must be of type datetime.datetime "
+                "and have tzinfo = datetime.timezone.utc"
             )
         else:
             schedule_list = []

--- a/src/aws_croniter/aws_croniter.py
+++ b/src/aws_croniter/aws_croniter.py
@@ -1,18 +1,18 @@
 import datetime
 import re
 
-from aws_croniter.exceptions import AWSCronExpressionDayOfMonthError
-from aws_croniter.exceptions import AWSCronExpressionDayOfWeekError
-from aws_croniter.exceptions import AWSCronExpressionError
-from aws_croniter.exceptions import AWSCronExpressionHourError
-from aws_croniter.exceptions import AWSCronExpressionMinuteError
-from aws_croniter.exceptions import AWSCronExpressionMonthError
-from aws_croniter.exceptions import AWSCronExpressionYearError
+from aws_croniter.exceptions import AwsCroniterExpressionDayOfMonthError
+from aws_croniter.exceptions import AwsCroniterExpressionDayOfWeekError
+from aws_croniter.exceptions import AwsCroniterExpressionError
+from aws_croniter.exceptions import AwsCroniterExpressionHourError
+from aws_croniter.exceptions import AwsCroniterExpressionMinuteError
+from aws_croniter.exceptions import AwsCroniterExpressionMonthError
+from aws_croniter.exceptions import AwsCroniterExpressionYearError
 from aws_croniter.occurrence import Occurrence
 from aws_croniter.utils import RegexUtils
 
 
-class AWSCron:
+class AwsCroniter:
     MONTH_REPLACES = [
         ["JAN", "1"],
         ["FEB", "2"],
@@ -66,30 +66,30 @@ class AWSCron:
         """
         value_count = len(self.cron.split(" "))
         if value_count != 6:
-            raise AWSCronExpressionError(
+            raise AwsCroniterExpressionError(
                 f"Incorrect number of values in '{self.cron}'. 6 required, {value_count} provided."
             )
 
         minute, hour, day_of_month, month, day_of_week, year = self.cron.split(" ")
 
         if not ((day_of_month == "?" and day_of_week != "?") or (day_of_month != "?" and day_of_week == "?")):
-            raise AWSCronExpressionError(
+            raise AwsCroniterExpressionError(
                 f"Invalid combination of day-of-month '{day_of_month}' and day-of-week '{day_of_week}'."
                 "One must be a question mark (?)"
             )
 
         if not re.fullmatch(RegexUtils.minute_regex(), minute):
-            raise AWSCronExpressionMinuteError(f"Invalid minute value '{minute}'.")
+            raise AwsCroniterExpressionMinuteError(f"Invalid minute value '{minute}'.")
         if not re.fullmatch(RegexUtils.hour_regex(), hour):
-            raise AWSCronExpressionHourError(f"Invalid hour value '{hour}'.")
+            raise AwsCroniterExpressionHourError(f"Invalid hour value '{hour}'.")
         if not re.fullmatch(RegexUtils.day_of_month_regex(), day_of_month):
-            raise AWSCronExpressionDayOfMonthError(f"Invalid day-of-month value '{day_of_month}'.")
+            raise AwsCroniterExpressionDayOfMonthError(f"Invalid day-of-month value '{day_of_month}'.")
         if not re.fullmatch(RegexUtils.month_regex(), month):
-            raise AWSCronExpressionMonthError(f"Invalid month value '{month}'.")
+            raise AwsCroniterExpressionMonthError(f"Invalid month value '{month}'.")
         if not re.fullmatch(RegexUtils.day_of_week_regex(), day_of_week):
-            raise AWSCronExpressionDayOfWeekError(f"Invalid day-of-week value '{day_of_week}'.")
+            raise AwsCroniterExpressionDayOfWeekError(f"Invalid day-of-week value '{day_of_week}'.")
         if not re.fullmatch(RegexUtils.year_regex(), year):
-            raise AWSCronExpressionYearError(f"Invalid year value '{year}'.")
+            raise AwsCroniterExpressionYearError(f"Invalid year value '{year}'.")
 
         # If validation passes, then parse the cron expression
         self.__parse()
@@ -112,8 +112,8 @@ class AWSCron:
         self.minutes = self.__parse_one_rule(self.rules[0], 0, 59)
         self.hours = self.__parse_one_rule(self.rules[1], 0, 23)
         self.days_of_month = self.__parse_one_rule(self.rules[2], 1, 31)
-        self.months = self.__parse_one_rule(self.__replace(self.rules[3], AWSCron.MONTH_REPLACES), 1, 12)
-        self.days_of_week = self.__parse_one_rule(self.__replace(self.rules[4], AWSCron.DAY_WEEK_REPLACES), 1, 7)
+        self.months = self.__parse_one_rule(self.__replace(self.rules[3], AwsCroniter.MONTH_REPLACES), 1, 12)
+        self.days_of_week = self.__parse_one_rule(self.__replace(self.rules[4], AwsCroniter.DAY_WEEK_REPLACES), 1, 7)
         self.years = self.__parse_one_rule(self.rules[5], 1970, 2199)
 
     @staticmethod
@@ -185,7 +185,7 @@ class AWSCron:
                 "Invalid from_date. Must be of type datetime.datetime" " and have tzinfo = datetime.timezone.utc"
             )
         else:
-            cron_iterator = AWSCron(cron)
+            cron_iterator = AwsCroniter(cron)
             for i in range(n):
                 from_date = cron_iterator.occurrence(from_date).next()
                 schedule_list.append(from_date)
@@ -209,7 +209,7 @@ class AWSCron:
                 "Invalid from_date. Must be of type datetime.datetime" " and have tzinfo = datetime.timezone.utc"
             )
         else:
-            cron_iterator = AWSCron(cron)
+            cron_iterator = AwsCroniter(cron)
             for i in range(n):
                 from_date = cron_iterator.occurrence(from_date).prev()
                 schedule_list.append(from_date)
@@ -244,7 +244,7 @@ class AWSCron:
             )
         else:
             schedule_list = []
-            cron_iterator = AWSCron(cron)
+            cron_iterator = AwsCroniter(cron)
             start = from_date.replace(second=0, microsecond=0) - datetime.timedelta(seconds=1)
             stop = to_date.replace(second=0, microsecond=0)
 

--- a/src/aws_croniter/exceptions.py
+++ b/src/aws_croniter/exceptions.py
@@ -1,40 +1,40 @@
-class AWSCronExpressionError(ValueError):
+class AwsCroniterExpressionError(ValueError):
     """Base exception for errors in AWS cron expressions."""
 
     pass
 
 
-class AWSCronExpressionMinuteError(AWSCronExpressionError):
+class AwsCroniterExpressionMinuteError(AwsCroniterExpressionError):
     """Exception raised for invalid minute values in an AWS cron expression."""
 
     pass
 
 
-class AWSCronExpressionHourError(AWSCronExpressionError):
+class AwsCroniterExpressionHourError(AwsCroniterExpressionError):
     """Exception raised for invalid hour values in an AWS cron expression."""
 
     pass
 
 
-class AWSCronExpressionMonthError(AWSCronExpressionError):
+class AwsCroniterExpressionMonthError(AwsCroniterExpressionError):
     """Exception raised for invalid month values in an AWS cron expression."""
 
     pass
 
 
-class AWSCronExpressionYearError(AWSCronExpressionError):
+class AwsCroniterExpressionYearError(AwsCroniterExpressionError):
     """Exception raised for invalid year values in an AWS cron expression."""
 
     pass
 
 
-class AWSCronExpressionDayOfMonthError(AWSCronExpressionError):
+class AwsCroniterExpressionDayOfMonthError(AwsCroniterExpressionError):
     """Exception raised for invalid day-of-month values in an AWS cron expression."""
 
     pass
 
 
-class AWSCronExpressionDayOfWeekError(AWSCronExpressionError):
+class AwsCroniterExpressionDayOfWeekError(AwsCroniterExpressionError):
     """Exception raised for invalid day-of-week values in an AWS cron expression."""
 
     pass

--- a/src/aws_croniter/occurrence.py
+++ b/src/aws_croniter/occurrence.py
@@ -9,16 +9,16 @@ from aws_croniter.utils import TimeUtils
 
 
 class Occurrence:
-    def __init__(self, AWSCron, utc_datetime):
+    def __init__(self, AwsCroniter, utc_datetime):
         if utc_datetime.tzinfo is None or utc_datetime.tzinfo != datetime.timezone.utc:
             raise Exception("Occurrence utc_datetime must have tzinfo == datetime.timezone.utc")
         self.utc_datetime = utc_datetime
-        self.cron = AWSCron
+        self.cron = AwsCroniter
         self.iter = 0
 
     def __find_once(self, parsed, datetime_from):
         if self.iter > 10:
-            raise Exception(f"AwsCronParser : this shouldn't happen, but iter {self.iter} > 10 ")
+            raise Exception(f"AwsCroniterParser : this shouldn't happen, but iter {self.iter} > 10 ")
         self.iter += 1
         current_year = datetime_from.year
         current_month = datetime_from.month
@@ -80,7 +80,7 @@ class Occurrence:
 
     def __find_prev_once(self, parsed, datetime_from: datetime):
         if self.iter > 10:
-            raise Exception("AwsCronParser : this shouldn't happen, but iter > 10")
+            raise Exception("AwsCroniterParser : this shouldn't happen, but iter > 10")
         self.iter += 1
         current_year = datetime_from.year
         current_month = datetime_from.month

--- a/src/aws_croniter/occurrence.py
+++ b/src/aws_croniter/occurrence.py
@@ -142,31 +142,31 @@ class Occurrence:
 
         return datetime.datetime(year, month, day_of_month, hour, minute, tzinfo=datetime.timezone.utc)
 
-    def next(self, datetime_inclusive=False):
+    def next(self, inclusive=False):
         """
         Generate the next occurrence after the current time.
 
-        :param datetime_inclusive: If True, include the current time if it matches a valid execution.
+        :param inclusive: If True, include the current time if it matches a valid execution.
         :return: The next occurrence as a datetime object.
         """
         self.iter = 0
         from_epoch = (math.floor(TimeUtils.datetime_to_millisec(self.utc_datetime) / 60000.0) + 1) * 60000
-        if datetime_inclusive:
+        if inclusive:
             # Do not add extra minute, include current time
             from_epoch = math.floor(TimeUtils.datetime_to_millisec(self.utc_datetime) / 60000.0) * 60000
         dt = datetime.datetime.fromtimestamp(from_epoch / 1000.0, tz=datetime.timezone.utc)
         return self.__find_once(self.cron, dt)
 
-    def prev(self, datetime_inclusive=False):
+    def prev(self, inclusive=False):
         """
         Generate the prev before the occurrence date value
 
-        :param datetime_inclusive: If True, include the current time if it matches a valid execution.
+        :param inclusive: If True, include the current time if it matches a valid execution.
         :return: The next occurrence as a datetime object.
         """
         self.iter = 0
         from_epoch = (math.floor(TimeUtils.datetime_to_millisec(self.utc_datetime) / 60000.0) - 1) * 60000
-        if datetime_inclusive:
+        if inclusive:
             # Do not subtract extra minute, include current time
             from_epoch = math.floor(TimeUtils.datetime_to_millisec(self.utc_datetime) / 60000.0) * 60000
         dt = datetime.datetime.fromtimestamp(from_epoch / 1000.0, tz=datetime.timezone.utc)

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -273,11 +273,12 @@ def test_get_all_schedule_bw_dates(from_dt, to_date, cron_expression, exclude_en
     """
     Parameterized test for retrieving all schedule times between dates.
     """
-    result = AwsCroniter.get_all_schedule_bw_dates(from_dt, to_date, cron_expression, exclude_ends)
+    itr = AwsCroniter(cron_expression)
+    result = itr.get_all_schedule_bw_dates(from_dt, to_date, exclude_ends)
     assert str(expected_list) == str(result)
 
 
-def test_get_next_n_schedule():
+def test_get_next():
     """Testing - retrieve n number of datetimes after start date when AWS cron expression is set to
     run every 23 minutes. cron(Minutes Hours Day-of-month Month Day-of-week Year)
     Where start datetime is 8/7/2021 8:30:57 UTC
@@ -295,11 +296,12 @@ def test_get_next_n_schedule():
         datetime.datetime(2021, 8, 7, 11, 46, tzinfo=datetime.timezone.utc),
     ]
     from_dt = datetime.datetime(2021, 8, 7, 8, 30, 57, tzinfo=datetime.timezone.utc)
-    result = AwsCroniter.get_next_n_schedule(10, from_dt, "0/23 * * * ? *")
-    assert str(expected_list) == str(result)  # noqa: S101
+    itr = AwsCroniter("0/23 * * * ? *")
+    result = itr.get_next(from_dt, 10)
+    assert str(expected_list) == str(result)
 
 
-def test_get_prev_n_schedule_1():
+def test_get_prev_1():
     """Testing - retrieve n number of datetimes before start date when AWS cron expression is set to
     run every 23 minutes. cron(Minutes Hours Day-of-month Month Day-of-week Year)
     Where start datetime is 8/7/2021 11:50:57 UTC
@@ -317,11 +319,12 @@ def test_get_prev_n_schedule_1():
         datetime.datetime(2021, 8, 7, 8, 46, tzinfo=datetime.timezone.utc),
     ]
     from_dt = datetime.datetime(2021, 8, 7, 11, 50, 57, tzinfo=datetime.timezone.utc)
-    result = AwsCroniter.get_prev_n_schedule(10, from_dt, "0/23 * * * ? *")
+    itr = AwsCroniter("0/23 * * * ? *")
+    result = itr.get_prev(from_dt, 10)
     assert str(expected_list) == str(result)
 
 
-def test_get_prev_n_schedule_2():
+def test_get_prev_2():
     """Testing - retrieve n number of datetimes before start date when AWS cron expression is set to
     run every 5 minutes Monday through Friday between 8:00 am and 5:55 pm (UTC).
     cron(Minutes Hours Day-of-month Month Day-of-week Year)
@@ -340,5 +343,6 @@ def test_get_prev_n_schedule_2():
         datetime.datetime(2021, 8, 16, 8, 0, tzinfo=datetime.timezone.utc),
     ]
     from_dt = datetime.datetime(2021, 8, 16, 8, 50, 57, tzinfo=datetime.timezone.utc)
-    result = AwsCroniter.get_prev_n_schedule(10, from_dt, "0/5 8-17 ? * MON-FRI *")
+    itr = AwsCroniter("0/5 8-17 ? * MON-FRI *")
+    result = itr.get_prev(from_dt, 10)
     assert str(expected_list) == str(result)

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -2,14 +2,14 @@ import datetime
 
 import pytest
 
-from aws_croniter.awscron import AWSCron
-from aws_croniter.exceptions import AWSCronExpressionDayOfMonthError
-from aws_croniter.exceptions import AWSCronExpressionDayOfWeekError
-from aws_croniter.exceptions import AWSCronExpressionError
-from aws_croniter.exceptions import AWSCronExpressionHourError
-from aws_croniter.exceptions import AWSCronExpressionMinuteError
-from aws_croniter.exceptions import AWSCronExpressionMonthError
-from aws_croniter.exceptions import AWSCronExpressionYearError
+from aws_croniter.aws_croniter import AwsCroniter
+from aws_croniter.exceptions import AwsCroniterExpressionDayOfMonthError
+from aws_croniter.exceptions import AwsCroniterExpressionDayOfWeekError
+from aws_croniter.exceptions import AwsCroniterExpressionError
+from aws_croniter.exceptions import AwsCroniterExpressionHourError
+from aws_croniter.exceptions import AwsCroniterExpressionMinuteError
+from aws_croniter.exceptions import AwsCroniterExpressionMonthError
+from aws_croniter.exceptions import AwsCroniterExpressionYearError
 
 
 @pytest.mark.parametrize(
@@ -129,7 +129,7 @@ from aws_croniter.exceptions import AWSCronExpressionYearError
 )
 def test_cron_expressions(cron_str, expected):
     # Validation followed by Parsing of cron expression
-    cron_obj = AWSCron(cron_str)
+    cron_obj = AwsCroniter(cron_str)
     assert expected["minutes"] == cron_obj.minutes
     assert expected["hours"] == cron_obj.hours
     assert expected["daysOfMonth"] == cron_obj.days_of_month
@@ -189,7 +189,7 @@ def test_cron_expressions(cron_str, expected):
 )
 def test_valid_cron_expression(cron_str):
     try:
-        AWSCron(cron_str)
+        AwsCroniter(cron_str)
     except Exception as e:
         pytest.fail(f"Valid cron expression '{cron_str}' raised an exception: {e}")
 
@@ -197,27 +197,27 @@ def test_valid_cron_expression(cron_str):
 @pytest.mark.parametrize(
     "cron_str,exception",
     [
-        ("0 18 ? * MON-FRI", AWSCronExpressionError),
-        ("0 18 * * * *", AWSCronExpressionError),
-        ("89 10 * * ? *", AWSCronExpressionMinuteError),
-        ("65/15 10 * * ? *", AWSCronExpressionMinuteError),
-        ("5/155 10 * * ? *", AWSCronExpressionMinuteError),
-        ("0 65 * * ? *", AWSCronExpressionHourError),
-        ("0 18 32W * ? *", AWSCronExpressionDayOfMonthError),
-        ("0 18 W * ? *", AWSCronExpressionDayOfMonthError),
-        ("10 10 31 04,09,13 ? *", AWSCronExpressionMonthError),
-        ("0 9 ? * 2#6 *", AWSCronExpressionDayOfWeekError),
-        ("0,5 07/12 ? * 01,05,8 *", AWSCronExpressionDayOfWeekError),
-        ("0,5 07/12 ? * 1 2000-2200", AWSCronExpressionYearError),
-        ("15/30 10 * * ? 2400", AWSCronExpressionYearError),
-        ("0 9 ? * ? *", AWSCronExpressionError),
-        ("0 18 3L * ? *", AWSCronExpressionDayOfMonthError),
-        ("0 1-7/2,11-23/2, * * ? *", AWSCronExpressionHourError),
+        ("0 18 ? * MON-FRI", AwsCroniterExpressionError),
+        ("0 18 * * * *", AwsCroniterExpressionError),
+        ("89 10 * * ? *", AwsCroniterExpressionMinuteError),
+        ("65/15 10 * * ? *", AwsCroniterExpressionMinuteError),
+        ("5/155 10 * * ? *", AwsCroniterExpressionMinuteError),
+        ("0 65 * * ? *", AwsCroniterExpressionHourError),
+        ("0 18 32W * ? *", AwsCroniterExpressionDayOfMonthError),
+        ("0 18 W * ? *", AwsCroniterExpressionDayOfMonthError),
+        ("10 10 31 04,09,13 ? *", AwsCroniterExpressionMonthError),
+        ("0 9 ? * 2#6 *", AwsCroniterExpressionDayOfWeekError),
+        ("0,5 07/12 ? * 01,05,8 *", AwsCroniterExpressionDayOfWeekError),
+        ("0,5 07/12 ? * 1 2000-2200", AwsCroniterExpressionYearError),
+        ("15/30 10 * * ? 2400", AwsCroniterExpressionYearError),
+        ("0 9 ? * ? *", AwsCroniterExpressionError),
+        ("0 18 3L * ? *", AwsCroniterExpressionDayOfMonthError),
+        ("0 1-7/2,11-23/2, * * ? *", AwsCroniterExpressionHourError),
     ],
 )
 def test_invalid_cron_expressions(cron_str, exception):
     with pytest.raises(exception):
-        AWSCron(cron_str)
+        AwsCroniter(cron_str)
 
 
 @pytest.mark.parametrize(
@@ -273,7 +273,7 @@ def test_get_all_schedule_bw_dates(from_dt, to_date, cron_expression, exclude_en
     """
     Parameterized test for retrieving all schedule times between dates.
     """
-    result = AWSCron.get_all_schedule_bw_dates(from_dt, to_date, cron_expression, exclude_ends)
+    result = AwsCroniter.get_all_schedule_bw_dates(from_dt, to_date, cron_expression, exclude_ends)
     assert str(expected_list) == str(result)
 
 
@@ -295,7 +295,7 @@ def test_get_next_n_schedule():
         datetime.datetime(2021, 8, 7, 11, 46, tzinfo=datetime.timezone.utc),
     ]
     from_dt = datetime.datetime(2021, 8, 7, 8, 30, 57, tzinfo=datetime.timezone.utc)
-    result = AWSCron.get_next_n_schedule(10, from_dt, "0/23 * * * ? *")
+    result = AwsCroniter.get_next_n_schedule(10, from_dt, "0/23 * * * ? *")
     assert str(expected_list) == str(result)  # noqa: S101
 
 
@@ -317,7 +317,7 @@ def test_get_prev_n_schedule_1():
         datetime.datetime(2021, 8, 7, 8, 46, tzinfo=datetime.timezone.utc),
     ]
     from_dt = datetime.datetime(2021, 8, 7, 11, 50, 57, tzinfo=datetime.timezone.utc)
-    result = AWSCron.get_prev_n_schedule(10, from_dt, "0/23 * * * ? *")
+    result = AwsCroniter.get_prev_n_schedule(10, from_dt, "0/23 * * * ? *")
     assert str(expected_list) == str(result)
 
 
@@ -340,5 +340,5 @@ def test_get_prev_n_schedule_2():
         datetime.datetime(2021, 8, 16, 8, 0, tzinfo=datetime.timezone.utc),
     ]
     from_dt = datetime.datetime(2021, 8, 16, 8, 50, 57, tzinfo=datetime.timezone.utc)
-    result = AWSCron.get_prev_n_schedule(10, from_dt, "0/5 8-17 ? * MON-FRI *")
+    result = AwsCroniter.get_prev_n_schedule(10, from_dt, "0/5 8-17 ? * MON-FRI *")
     assert str(expected_list) == str(result)

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -301,48 +301,47 @@ def test_get_next():
     assert str(expected_list) == str(result)
 
 
-def test_get_prev_1():
-    """Testing - retrieve n number of datetimes before start date when AWS cron expression is set to
-    run every 23 minutes. cron(Minutes Hours Day-of-month Month Day-of-week Year)
-    Where start datetime is 8/7/2021 11:50:57 UTC
-    """
-    expected_list = [
-        datetime.datetime(2021, 8, 7, 11, 46, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 11, 23, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 11, 0, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 10, 46, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 10, 23, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 10, 0, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 9, 46, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 9, 23, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 9, 0, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 8, 46, tzinfo=datetime.timezone.utc),
-    ]
-    from_dt = datetime.datetime(2021, 8, 7, 11, 50, 57, tzinfo=datetime.timezone.utc)
-    itr = AwsCroniter("0/23 * * * ? *")
-    result = itr.get_prev(from_dt, 10)
-    assert str(expected_list) == str(result)
-
-
-def test_get_prev_2():
-    """Testing - retrieve n number of datetimes before start date when AWS cron expression is set to
-    run every 5 minutes Monday through Friday between 8:00 am and 5:55 pm (UTC).
-    cron(Minutes Hours Day-of-month Month Day-of-week Year)
-    Where start datetime is 8/16/2021 8:50:57 UTC
-    """
-    expected_list = [
-        datetime.datetime(2021, 8, 16, 8, 45, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 40, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 35, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 30, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 25, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 20, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 15, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 10, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 5, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 16, 8, 0, tzinfo=datetime.timezone.utc),
-    ]
-    from_dt = datetime.datetime(2021, 8, 16, 8, 50, 57, tzinfo=datetime.timezone.utc)
-    itr = AwsCroniter("0/5 8-17 ? * MON-FRI *")
-    result = itr.get_prev(from_dt, 10)
+@pytest.mark.parametrize(
+    "cron_expr, from_dt, n, expected_list",
+    [
+        (
+            "0/23 * * * ? *",
+            datetime.datetime(2021, 8, 7, 11, 50, 57, tzinfo=datetime.timezone.utc),
+            10,
+            [
+                datetime.datetime(2021, 8, 7, 11, 46, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 11, 23, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 11, 0, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 10, 46, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 10, 23, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 10, 0, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 9, 46, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 9, 23, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 9, 0, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 8, 46, tzinfo=datetime.timezone.utc),
+            ],
+        ),
+        (
+            "0/5 8-17 ? * MON-FRI *",
+            datetime.datetime(2021, 8, 16, 8, 50, 57, tzinfo=datetime.timezone.utc),
+            10,
+            [
+                datetime.datetime(2021, 8, 16, 8, 45, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 40, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 35, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 30, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 25, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 20, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 15, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 10, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 5, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 16, 8, 0, tzinfo=datetime.timezone.utc),
+            ],
+        ),
+    ],
+)
+def test_get_prev(cron_expr, from_dt, n, expected_list):
+    """Parameterized test for get_prev method."""
+    itr = AwsCroniter(cron_expr)
+    result = itr.get_prev(from_dt, n)
     assert str(expected_list) == str(result)

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -278,6 +278,28 @@ def test_get_all_schedule_bw_dates(from_dt, to_date, cron_expression, exclude_en
     assert str(expected_list) == str(result)
 
 
+@pytest.mark.parametrize(
+    "from_date, to_date, expected_error",
+    [
+        (
+            "invalid_date",
+            datetime.datetime(2021, 8, 7, 8, 46, 57, tzinfo=datetime.timezone.utc),
+            "The from_date and to_date must be same type. <class 'str'> != <class 'datetime.datetime'>",
+        ),
+        (
+            "invalid_date",
+            "invalid_date",
+            "Invalid from_date and to_date. Must be of type datetime.datetime and have tzinfo = datetime.timezone.utc",
+        ),
+    ],
+)
+def test_get_all_schedule_bw_dates_errors(from_date, to_date, expected_error):
+    """Test that get_all_schedule_bw_dates raises ValueError for invalid from_date or to_date."""
+    itr = AwsCroniter("0/5 8-17 ? * MON-FRI *")
+    with pytest.raises(ValueError, match=expected_error):
+        itr.get_all_schedule_bw_dates(from_date, to_date)
+
+
 def test_get_next():
     """Testing - retrieve n number of datetimes after start date when AWS cron expression is set to
     run every 23 minutes. cron(Minutes Hours Day-of-month Month Day-of-week Year)
@@ -299,6 +321,13 @@ def test_get_next():
     itr = AwsCroniter("0/23 * * * ? *")
     result = itr.get_next(from_dt, 10)
     assert str(expected_list) == str(result)
+
+
+def test_get_next_error():
+    expected_error = "Invalid from_date. Must be of type datetime.datetime and have tzinfo = datetime.timezone.utc"
+    itr = AwsCroniter("0/5 8-17 ? * MON-FRI *")
+    with pytest.raises(ValueError, match=expected_error):
+        itr.get_next("invalid_date")
 
 
 @pytest.mark.parametrize(
@@ -345,3 +374,10 @@ def test_get_prev(cron_expr, from_dt, n, expected_list):
     itr = AwsCroniter(cron_expr)
     result = itr.get_prev(from_dt, n)
     assert str(expected_list) == str(result)
+
+
+def test_get_prev_error():
+    expected_error = "Invalid from_date. Must be of type datetime.datetime and have tzinfo = datetime.timezone.utc"
+    itr = AwsCroniter("0/5 8-17 ? * MON-FRI *")
+    with pytest.raises(ValueError, match=expected_error):
+        itr.get_prev("invalid_date")

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -5,12 +5,12 @@ import pytest
 from aws_croniter.aws_croniter import AwsCroniter
 
 
-def test_generate_next_occurrence_with_datetime_inclusive():
+def test_generate_next_occurrence_with_inclusive():
     cron = "23 17 25 7 ? 2020"
     expected_occurrence = "2020-07-25 17:23:00+00:00"
     cron = AwsCroniter(cron)
     dt = datetime.datetime(2020, 7, 25, 17, 23, 57, tzinfo=datetime.timezone.utc)
-    dt = cron.occurrence(dt).next(datetime_inclusive=True)
+    dt = cron.occurrence(dt).next(inclusive=True)
     assert expected_occurrence == str(dt)
 
 
@@ -208,10 +208,10 @@ def test_generate_multiple_prev_occurrences1():
         assert str(dt) == expected
 
 
-def test_generate_prev_occurrence_with_datetime_inclusive():
+def test_generate_prev_occurrence_with_inclusive():
     cron = "23 17 25 7 ? 2020"
     expected_occurrence = "2020-07-25 17:23:00+00:00"
     cron = AwsCroniter(cron)
     dt = datetime.datetime(2020, 7, 25, 17, 23, 57, tzinfo=datetime.timezone.utc)
-    dt = cron.occurrence(dt).prev(datetime_inclusive=True)
+    dt = cron.occurrence(dt).prev(inclusive=True)
     assert expected_occurrence == str(dt)

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -2,13 +2,13 @@ import datetime
 
 import pytest
 
-from aws_croniter.awscron import AWSCron
+from aws_croniter.aws_croniter import AwsCroniter
 
 
 def test_generate_next_occurrence_with_datetime_inclusive():
     cron = "23 17 25 7 ? 2020"
     expected_occurrence = "2020-07-25 17:23:00+00:00"
-    cron = AWSCron(cron)
+    cron = AwsCroniter(cron)
     dt = datetime.datetime(2020, 7, 25, 17, 23, 57, tzinfo=datetime.timezone.utc)
     dt = cron.occurrence(dt).next(datetime_inclusive=True)
     assert expected_occurrence == str(dt)
@@ -171,7 +171,7 @@ def test_generate_next_occurrence_with_datetime_inclusive():
     ],
 )
 def test_generate_next_occurrences(cron_expression, expected_list, start_datetime):
-    cron = AWSCron(cron_expression)
+    cron = AwsCroniter(cron_expression)
     dt = start_datetime
     for expected in expected_list:
         dt = cron.occurrence(dt).next()
@@ -200,7 +200,7 @@ def test_generate_multiple_prev_occurrences1():
         "2019-11-25 17:25:00+00:00",
     ]
 
-    cron = AWSCron(cron)
+    cron = AwsCroniter(cron)
     dt = datetime.datetime(2020, 5, 9, 22, 30, 57, tzinfo=datetime.timezone.utc)
 
     for expected in expected_list:
@@ -211,7 +211,7 @@ def test_generate_multiple_prev_occurrences1():
 def test_generate_prev_occurrence_with_datetime_inclusive():
     cron = "23 17 25 7 ? 2020"
     expected_occurrence = "2020-07-25 17:23:00+00:00"
-    cron = AWSCron(cron)
+    cron = AwsCroniter(cron)
     dt = datetime.datetime(2020, 7, 25, 17, 23, 57, tzinfo=datetime.timezone.utc)
     dt = cron.occurrence(dt).prev(datetime_inclusive=True)
     assert expected_occurrence == str(dt)


### PR DESCRIPTION
- Changed class name from `AWSCron` to `AwsCroniter` to follow the naming convention and match the package name
- Renamed and refactors methods from class `AwsCroniter` to make them more readable and keep the method name concise
- Refactored `AwsCroniter` to ensure that it acts as a single entry point for all methods.  
   - The object of this class is now used to call other methods as `get_next`, `get_prev` etc.
   - This reduces passing the CRON expression to every method.
- Improved test coverage
- Reduced test duplications and parametrised few of them
- Updated Readme with valid example usage of the package
- Updated `__init__.py` to allow importing the class `AwsCroniter` directly from the package.