### PR TITLE
Fix AttributeError in AwsCroniter.get_next for certain cron expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ except AwsCroniterExpressionError as e:
 
 ### **Fetching the Next Occurrence**
 
-The `get_next` method retrieves the next occurrence(s) of the cron schedule from a specified date.
+The `get_next` method retrieves the next occurrence(s) of the cron schedule from a specified date. This method
+always returns a list with `n` items and sets the items to `None` if no valid occurrences are found.
 
 #### **Basic Usage**
 
@@ -168,7 +169,8 @@ print(next_occurrence_inclusive)
 
 ### **Fetching the Previous Occurrence**
 
-The `get_prev` method retrieves the previous occurrence(s) of the cron schedule from a specified date.
+The `get_prev` method retrieves the previous occurrence(s) of the cron schedule from a specified date. This method
+always returns a list with `n` items and sets the items to `None` if no valid occurrences are found.
 
 #### **Basic Usage**
 

--- a/src/aws_croniter/aws_croniter.py
+++ b/src/aws_croniter/aws_croniter.py
@@ -180,10 +180,12 @@ class AwsCroniter:
                 "Invalid from_date. Must be of type datetime.datetime and have tzinfo = datetime.timezone.utc"
             )
         else:
-            schedule_list = list()
+            schedule_list = [None] * n
             for i in range(n):
                 from_date = self.occurrence(from_date).next(inclusive=(inclusive and i == 0))
-                schedule_list.append(from_date)
+                if from_date is None:
+                    break
+                schedule_list[i] = from_date
 
             return schedule_list
 
@@ -202,10 +204,12 @@ class AwsCroniter:
                 "Invalid from_date. Must be of type datetime.datetime and have tzinfo = datetime.timezone.utc"
             )
         else:
-            schedule_list = list()
+            schedule_list = [None] * n
             for i in range(n):
                 from_date = self.occurrence(from_date).prev(inclusive=(inclusive and i == 0))
-                schedule_list.append(from_date)
+                if from_date is None:
+                    break
+                schedule_list[i] = from_date
 
             return schedule_list
 

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -300,26 +300,52 @@ def test_get_all_schedule_bw_dates_errors(from_date, to_date, expected_error):
         itr.get_all_schedule_bw_dates(from_date, to_date)
 
 
-def test_get_next():
-    """Testing - retrieve n number of datetimes after start date when AWS cron expression is set to
-    run every 23 minutes. cron(Minutes Hours Day-of-month Month Day-of-week Year)
-    Where start datetime is 8/7/2021 8:30:57 UTC
+@pytest.mark.parametrize(
+    "cron_expression, from_dt, n, expected_list",
+    [
+        (
+            "0/23 * * * ? *",
+            datetime.datetime(2021, 8, 7, 8, 30, 57, tzinfo=datetime.timezone.utc),
+            10,
+            [
+                datetime.datetime(2021, 8, 7, 8, 46, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 9, 0, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 9, 23, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 9, 46, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 10, 0, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 10, 23, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 10, 46, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 11, 0, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 11, 23, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2021, 8, 7, 11, 46, tzinfo=datetime.timezone.utc),
+            ],
+        ),
+        (
+            "0 12 15 * ? 2023",
+            datetime.datetime(2023, 12, 14, tzinfo=datetime.timezone.utc),
+            10,
+            [
+                datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+        ),
+    ],
+)
+def test_get_next_parameterized(cron_expression, from_dt, n, expected_list):
     """
-    expected_list = [
-        datetime.datetime(2021, 8, 7, 8, 46, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 9, 0, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 9, 23, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 9, 46, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 10, 0, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 10, 23, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 10, 46, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 11, 0, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 11, 23, tzinfo=datetime.timezone.utc),
-        datetime.datetime(2021, 8, 7, 11, 46, tzinfo=datetime.timezone.utc),
-    ]
-    from_dt = datetime.datetime(2021, 8, 7, 8, 30, 57, tzinfo=datetime.timezone.utc)
-    itr = AwsCroniter("0/23 * * * ? *")
-    result = itr.get_next(from_dt, 10)
+    Parameterized test for get_next method of AwsCroniter.
+    Tests retrieving n number of datetimes after start date for different AWS cron expressions.
+    """
+    itr = AwsCroniter(cron_expression)
+    result = itr.get_next(from_dt, n)
     assert str(expected_list) == str(result)
 
 
@@ -365,6 +391,23 @@ def test_get_next_error():
                 datetime.datetime(2021, 8, 16, 8, 10, tzinfo=datetime.timezone.utc),
                 datetime.datetime(2021, 8, 16, 8, 5, tzinfo=datetime.timezone.utc),
                 datetime.datetime(2021, 8, 16, 8, 0, tzinfo=datetime.timezone.utc),
+            ],
+        ),
+        (
+            "0 12 15 1 ? 2023",
+            datetime.datetime(2023, 2, 14, tzinfo=datetime.timezone.utc),
+            10,
+            [
+                datetime.datetime(2023, 1, 15, 12, 0, tzinfo=datetime.timezone.utc),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
             ],
         ),
     ],


### PR DESCRIPTION
This PR fixes #7 
- Handle cases where self.occurrence(from_date) returns None in get_next method
- Prevent AttributeError when processing cron expressions with no future occurrences
- Ensure get_next always returns a list of length n, filling with None for invalid dates
- Improve robustness of the AwsCroniter class for edge cases
- Update unit tests to cover the fixed scenario
- The same changes have been made for the get_prev() method
- Updated the Readme with this change