### PR TITLE
Fix ValueError in __parse_one_rule for complex rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 AWS Croniter is a Python package for parsing, validating, and calculating occurrences of AWS EventBridge cron
 expressions. AWS cron expressions are a powerful way to schedule events, but they differ from standard Unix cron syntax.
-This library makes it easy to work with AWS-specific cron schedules programmatically.
+This library makes it easy to work
+with [AWS-specific cron](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-scheduled-rule-pattern.html#eb-cron-expressions)
+schedules programmatically.
 
 ---
 

--- a/src/aws_croniter/aws_croniter.py
+++ b/src/aws_croniter/aws_croniter.py
@@ -128,41 +128,32 @@ class AwsCroniter:
         if "#" in rule:
             return ["#", int(rule.split("#")[0]), int(rule.split("#")[1])]
 
-        new_rule = None
-        if rule == "*":
-            new_rule = str(min_value) + "-" + str(max_value)
-        elif "/" in rule:
-            parts = rule.split("/")
-            start = None
-            end = None
-            if parts[0] == "*":
-                start = min_value
-                end = max_value
-            elif "-" in parts[0]:
-                splits = parts[0].split("-")
-                start = int(splits[0])
-                end = int(splits[1])
-            else:
-                start = int(parts[0])
-                end = max_value
-            increment = int(parts[1])
-            new_rule = ""
-            while start <= end:
-                new_rule += "," + str(start)
-                start += increment
-            new_rule = new_rule[1:]
-        else:
-            new_rule = rule
         allows = []
-        for s in new_rule.split(","):
-            if "-" in s:
-                parts = s.split("-")
-                start = int(parts[0])
-                end = int(parts[1])
-                for i in range(start, end + 1, 1):
-                    allows.append(i)
+        for subrule in rule.split(","):
+            if "/" in subrule:
+                parts = subrule.split("/")
+                start = None
+                end = None
+                if parts[0] == "*":
+                    start = min_value
+                    end = max_value
+                elif "-" in parts[0]:
+                    splits = parts[0].split("-")
+                    start = int(splits[0])
+                    end = int(splits[1])
+                else:
+                    start = int(parts[0])
+                    end = max_value
+                increment = int(parts[1])
+                allows.extend(range(start, end + 1, increment))
+            elif "-" in subrule:
+                start, end = map(int, subrule.split("-"))
+                allows.extend(range(start, end + 1))
+            elif subrule == "*":
+                allows.extend(range(min_value, max_value + 1))
             else:
-                allows.append(int(s))
+                allows.append(int(subrule))
+
         allows.sort()
         return allows
 

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -178,9 +178,9 @@ def test_cron_expressions(cron_str, expected):
         "0 11-23/4 ? * 2-6 *",
         "0 11-23/2 * * ? *",
         "0 0 1 1-12/3 ? *",
-        # "0 1-7/2,11-23/2 * * ? *", # TODO: To be fixed in later versions
-        # "0 1-7/2,11-23/2,10 * * ? *", # TODO: To be fixed in later versions
-        # "30 0 1 JAN-APR,JUL-OCT/2,DEC ? *", # TODO: To be fixed in later versions
+        "0 1-7/2,11-23/2 * * ? *",
+        "0 1-7/2,11-23/2,10 * * ? *",
+        "30 0 1 JAN-APR,JUL-OCT/2,DEC ? *",
         "15 10 ? * L 2019-2022",
         "15 10 ? * 6L 2019-2022",
         "15 10 ? * FRIL 2019-2022",


### PR DESCRIPTION
This fixes - #9 
- Restructure method to handle multiple comma-separated rules
- Process each subrule individually for different cases
- Handle range with increment, simple range, wildcard, and single value
- Ensure correct parsing of rules like "1-7/2,11-23/2,10" by writing test cases
- Added link to AWS Cron syntax and rules