### PR TITLE
Fixing invalid AwsCroniterExpressionDayOfMonthError error

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -288,6 +288,33 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "ruff"
+version = "0.9.2"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.9.2-py3-none-linux_armv6l.whl", hash = "sha256:80605a039ba1454d002b32139e4970becf84b5fee3a3c3bf1c2af6f61a784347"},
+    {file = "ruff-0.9.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b9aab82bb20afd5f596527045c01e6ae25a718ff1784cb92947bff1f83068b00"},
+    {file = "ruff-0.9.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fbd337bac1cfa96be615f6efcd4bc4d077edbc127ef30e2b8ba2a27e18c054d4"},
+    {file = "ruff-0.9.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b35259b0cbf8daa22a498018e300b9bb0174c2bbb7bcba593935158a78054d"},
+    {file = "ruff-0.9.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b6a9701d1e371bf41dca22015c3f89769da7576884d2add7317ec1ec8cb9c3c"},
+    {file = "ruff-0.9.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9cc53e68b3c5ae41e8faf83a3b89f4a5d7b2cb666dff4b366bb86ed2a85b481f"},
+    {file = "ruff-0.9.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8efd9da7a1ee314b910da155ca7e8953094a7c10d0c0a39bfde3fcfd2a015684"},
+    {file = "ruff-0.9.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3292c5a22ea9a5f9a185e2d131dc7f98f8534a32fb6d2ee7b9944569239c648d"},
+    {file = "ruff-0.9.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1a605fdcf6e8b2d39f9436d343d1f0ff70c365a1e681546de0104bef81ce88df"},
+    {file = "ruff-0.9.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c547f7f256aa366834829a08375c297fa63386cbe5f1459efaf174086b564247"},
+    {file = "ruff-0.9.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d18bba3d3353ed916e882521bc3e0af403949dbada344c20c16ea78f47af965e"},
+    {file = "ruff-0.9.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b338edc4610142355ccf6b87bd356729b62bf1bc152a2fad5b0c7dc04af77bfe"},
+    {file = "ruff-0.9.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:492a5e44ad9b22a0ea98cf72e40305cbdaf27fac0d927f8bc9e1df316dcc96eb"},
+    {file = "ruff-0.9.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:af1e9e9fe7b1f767264d26b1075ac4ad831c7db976911fa362d09b2d0356426a"},
+    {file = "ruff-0.9.2-py3-none-win32.whl", hash = "sha256:71cbe22e178c5da20e1514e1e01029c73dc09288a8028a5d3446e6bba87a5145"},
+    {file = "ruff-0.9.2-py3-none-win_amd64.whl", hash = "sha256:c5e1d6abc798419cf46eed03f54f2e0c3adb1ad4b801119dedf23fcaf69b55b5"},
+    {file = "ruff-0.9.2-py3-none-win_arm64.whl", hash = "sha256:a1b63fa24149918f8b37cef2ee6fff81f24f0d74b6f0bdc37bc3e1f2143e41c6"},
+    {file = "ruff-0.9.2.tar.gz", hash = "sha256:b5eceb334d55fae5f316f783437392642ae18e16dcf4f1858d55d3c2a0f8f5d0"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -400,4 +427,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "abcb2c0747594f236e502e320a2301a7a8848e9fdcd742aa3da85f7e3fb26ad2"
+content-hash = "1c70882c4102ec11728c2a8244fbc33ef9ebdd1c730daddf9705c645da7f6176"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ coverage = "^7.6"
 pytest = "^8.0.0"
 pytest-cov = "^5.0"
 tox = "^4.23.2"
+ruff = "^0.9.2"
 
 
 [tool.pytest.ini_options]

--- a/src/aws_croniter/utils.py
+++ b/src/aws_croniter/utils.py
@@ -50,7 +50,7 @@ class RegexUtils:
     @classmethod
     def day_of_month_regex(cls) -> str:
         return (
-            rf"^({cls.common_regex(cls.MONTH_OF_DAY_VALUES)}|\?|L|L-[1-9]|[1-2][0-9]|3[0-1]|LW|{cls.MONTH_OF_DAY_VALUES}W)$"
+            rf"^({cls.common_regex(cls.MONTH_OF_DAY_VALUES)}|\?|L|L-({cls.MONTH_OF_DAY_VALUES})|LW|{cls.MONTH_OF_DAY_VALUES}W)$"
             # values , - * / ? L W
         )
 

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -104,6 +104,17 @@ from aws_croniter.exceptions import AwsCroniterExpressionYearError
             },
         ),
         (
+            "30 9 L-21 * ? *",
+            {
+                "minutes": [30],
+                "hours": [9],
+                "daysOfMonth": ["L", 21],
+                "months": list(range(1, 13)),
+                "daysOfWeek": [],
+                "years": [x for x in range(1970, 2199 + 1)],
+            },
+        ),
+        (
             "30 9 3W * ? *",
             {
                 "minutes": [30],
@@ -124,6 +135,7 @@ from aws_croniter.exceptions import AwsCroniterExpressionYearError
         "Every-5-hours-on-7th-2020",
         "Every-5-minutes-in-May-2020-2022",
         "Second-last-day-of-month",
+        "Last-day-minus-21-day-of-month",
         "Closest-weekday-to-3rd",
     ],
 )


### PR DESCRIPTION
This PR fixes #12 

- `L-` in cron expression was raising an error when it was followed by double digit. Fixed this by updating the `dat_of_month_regex`
- Added `ruff` package to `test.dependencies` which is used in linting.
- Added test case for this edge case