### PR TITLE
Fix invalid date handling in cron occurrence calculation

### DIFF
--- a/src/aws_croniter/occurrence.py
+++ b/src/aws_croniter/occurrence.py
@@ -16,6 +16,13 @@ class Occurrence:
         self.cron = AwsCroniter
         self.iter = 0
 
+    def __is_valid_date(self, year, month, day):
+        try:
+            datetime.datetime(year, month, day)
+            return True
+        except ValueError:
+            return False
+
     def __find_once(self, parsed, datetime_from):
         if self.iter > 10:
             raise Exception(f"AwsCroniterParser : this shouldn't happen, but iter {self.iter} > 10 ")
@@ -56,7 +63,7 @@ class Occurrence:
             day_of_month = SequenceUtils.array_find_first(
                 p_days_of_month, lambda c: c >= (current_day_of_month if is_same_month else 1)
             )
-        if not day_of_month:
+        if not day_of_month or not self.__is_valid_date(year, month, day_of_month):
             dt = datetime.datetime(year, month, 1, tzinfo=datetime.timezone.utc) + relativedelta(months=+1)
             return self.__find_once(parsed, dt)
 

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -349,6 +349,23 @@ def test_get_all_schedule_bw_dates_errors(from_date, to_date, expected_error):
                 None,
             ],
         ),
+        (
+            "30 9 1/4 2 ? 2025",
+            datetime.datetime(2025, 1, 21, tzinfo=datetime.timezone.utc),
+            10,
+            [
+                datetime.datetime(2025, 2, 1, 9, 30, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2025, 2, 5, 9, 30, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2025, 2, 9, 9, 30, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2025, 2, 13, 9, 30, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2025, 2, 17, 9, 30, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2025, 2, 21, 9, 30, tzinfo=datetime.timezone.utc),
+                datetime.datetime(2025, 2, 25, 9, 30, tzinfo=datetime.timezone.utc),
+                None,
+                None,
+                None,
+            ],
+        ),
     ],
 )
 def test_get_next_parameterized(cron_expression, from_dt, n, expected_list):


### PR DESCRIPTION
This fixes the #11 issue. 
This commit addresses an issue where the cron occurrence calculation could attempt to create invalid dates, such as February 29th in non-leap years. The changes include:

- Combining two separate checks for day_of_month validity into a single condition for efficiency.
- Implementing a helper method __is_valid_date to verify date validity.
- Ensuring that when an invalid date is encountered, the calculation moves to the next month and continues the search.
- Added test cases to cover this change.