### PR TITLE
[15] Bug Fix for infinite loop while trying to get next or prev occurrence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-croniter"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Python utility for AWS cron expressions. Validate and parse AWS EventBridge cron expressions seamlessly."
 authors = ["Siddarth Patil <siddarth3639@gmail.com>"]
 license = "MIT"

--- a/src/aws_croniter/occurrence.py
+++ b/src/aws_croniter/occurrence.py
@@ -25,7 +25,11 @@ class Occurrence:
 
     def __find_once(self, parsed, datetime_from):
         if self.iter > 10:
-            raise Exception(f"AwsCroniterParser : this shouldn't happen, but iter {self.iter} > 10 ")
+            # This shouldn't happen, but iter > 10. This means that the method has been called recursively more than 10
+            # times and still not found any valid date.
+            # This is a safety check to prevent infinite loop. NONE is returned in this case. Example AWS cron
+            # expression when this can occur is "30 9 L-30 2 ? *"
+            return None
         self.iter += 1
         current_year = datetime_from.year
         current_month = datetime_from.month
@@ -87,7 +91,11 @@ class Occurrence:
 
     def __find_prev_once(self, parsed, datetime_from: datetime):
         if self.iter > 10:
-            raise Exception("AwsCroniterParser : this shouldn't happen, but iter > 10")
+            # This shouldn't happen, but iter > 10. This means that the method has been called recursively more than 10
+            # times and still not found any valid date.
+            # This is a safety check to prevent infinite loop. NONE is returned in this case. Example AWS cron
+            # expression when this can occur is "30 9 L-30 2 ? *"
+            return None
         self.iter += 1
         current_year = datetime_from.year
         current_month = datetime_from.month
@@ -127,7 +135,7 @@ class Occurrence:
                 p_days_of_month, lambda c: c <= (current_day_of_month if is_same_month else 31)
             )
 
-        if not day_of_month:
+        if not day_of_month or not self.__is_valid_date(year, month, day_of_month):
             dt = datetime.datetime(year, month, 1, tzinfo=datetime.timezone.utc) + relativedelta(seconds=-1)
             return self.__find_prev_once(parsed, dt)
 

--- a/src/aws_croniter/utils.py
+++ b/src/aws_croniter/utils.py
@@ -8,6 +8,7 @@ class RegexUtils:
     MINUTE_VALUES = r"(0?[0-9]|[1-5][0-9])"  # [0]0-59
     HOUR_VALUES = r"(0?[0-9]|1[0-9]|2[0-3])"  # [0]0-23
     MONTH_OF_DAY_VALUES = r"(0?[1-9]|[1-2][0-9]|3[0-1])"  # [0]1-31
+    MONTH_OF_DAY_VALUES_WITH_L = r"(0?[1-9]|[1-2][0-9]|30)"  # [0]1-30
     MONTH_VALUES = r"(?i:0?[1-9]|1[0-2]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)"  # [0]1-12 or JAN-DEC
     DAY_OF_WEEK_VALUES = r"(?i:[1-7]|SUN|MON|TUE|WED|THU|FRI|SAT)"  # 1-7 or SAT-SUN
     DAY_OF_WEEK_HASH = rf"({DAY_OF_WEEK_VALUES}#[1-5])"  # Day of the week in the Nth week of the month
@@ -50,7 +51,7 @@ class RegexUtils:
     @classmethod
     def day_of_month_regex(cls) -> str:
         return (
-            rf"^({cls.common_regex(cls.MONTH_OF_DAY_VALUES)}|\?|L|L-({cls.MONTH_OF_DAY_VALUES})|LW|{cls.MONTH_OF_DAY_VALUES}W)$"
+            rf"^({cls.common_regex(cls.MONTH_OF_DAY_VALUES)}|\?|L|L-({cls.MONTH_OF_DAY_VALUES_WITH_L})|LW|{cls.MONTH_OF_DAY_VALUES}W)$"
             # values , - * / ? L W
         )
 

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -1,4 +1,6 @@
 import datetime
+from datetime import UTC
+from datetime import datetime as dt
 
 import pytest
 
@@ -224,6 +226,7 @@ def test_valid_cron_expression(cron_str):
         ("15/30 10 * * ? 2400", AwsCroniterExpressionYearError),
         ("0 9 ? * ? *", AwsCroniterExpressionError),
         ("0 18 3L * ? *", AwsCroniterExpressionDayOfMonthError),
+        ("0 18 L-31 * ? *", AwsCroniterExpressionDayOfMonthError),
         ("0 1-7/2,11-23/2, * * ? *", AwsCroniterExpressionHourError),
     ],
 )
@@ -366,6 +369,15 @@ def test_get_all_schedule_bw_dates_errors(from_date, to_date, expected_error):
                 None,
             ],
         ),
+        (
+            "30 9 L-30 2 ? *",
+            dt.now(tz=UTC),
+            2,
+            [
+                None,
+                None,
+            ],
+        ),
     ],
 )
 def test_get_next_parameterized(cron_expression, from_dt, n, expected_list):
@@ -435,6 +447,15 @@ def test_get_next_error():
                 None,
                 None,
                 None,
+                None,
+                None,
+            ],
+        ),
+        (
+            "30 9 L-30 2 ? *",
+            dt.now(tz=UTC),
+            2,
+            [
                 None,
                 None,
             ],

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -1,6 +1,4 @@
 import datetime
-from datetime import UTC
-from datetime import datetime as dt
 
 import pytest
 
@@ -371,7 +369,7 @@ def test_get_all_schedule_bw_dates_errors(from_date, to_date, expected_error):
         ),
         (
             "30 9 L-30 2 ? *",
-            dt.now(tz=UTC),
+            datetime.datetime(2025, 1, 21, tzinfo=datetime.timezone.utc),
             2,
             [
                 None,
@@ -453,7 +451,7 @@ def test_get_next_error():
         ),
         (
             "30 9 L-30 2 ? *",
-            dt.now(tz=UTC),
+            datetime.datetime(2025, 1, 21, tzinfo=datetime.timezone.utc),
             2,
             [
                 None,


### PR DESCRIPTION
This is a fix for #15 
- Updated `day_of_month_regex` to only allow `L-1` to `L-30` and exclude `L-31`.
- Updated `__find_once` and `__find_prev_once` to break infinite loop by returning `None`.
- Added `__is_valid_date` validation inside `__find_prev_once` method to make sure valid date is returned.
- Added required test cases.
- Patch version Bump