### PR TITLE
Fix: Make to_date exclusive in get_final_execution_time (Issue #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ print(all_occurrences_exclude_ends)
 ### **Get Final Execution Time**
 
 The `get_final_execution_time` method retrieves the final execution datetime between two specified dates.
+The `to_date` is exclusive, meaning if it exactly matches the cron expression, it will not be included
+in the result. Only executions strictly before `to_date` will be returned.
 
 #### **Basic Usage**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-croniter"
-version = "1.0.3"
+version = "1.0.4"
 description = "A Python utility for AWS cron expressions. Validate and parse AWS EventBridge cron expressions seamlessly."
 authors = ["Siddarth Patil <siddarth3639@gmail.com>"]
 license = "MIT"

--- a/tests/test_awscron.py
+++ b/tests/test_awscron.py
@@ -487,7 +487,7 @@ def test_get_prev_error():
             "0/30 * * * ? *",  # Every 30 minutes
             datetime.datetime(2021, 8, 7, 8, 0, 0, tzinfo=datetime.timezone.utc),
             datetime.datetime(2021, 8, 7, 11, 0, 0, tzinfo=datetime.timezone.utc),
-            datetime.datetime(2021, 8, 7, 11, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2021, 8, 7, 10, 30, tzinfo=datetime.timezone.utc),
         ),
         # Test case 2: Specific date with single execution
         (
@@ -496,12 +496,12 @@ def test_get_prev_error():
             datetime.datetime(2023, 12, 31, tzinfo=datetime.timezone.utc),
             datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
         ),
-        # Test case 3: End date matches the execution (inclusive=True behavior)
+        # Test case 3: End date matches the execution (to_date is exclusive)
         (
             "0 12 15 * ? 2023",  # 15th of every month at 12:00 PM in 2023
             datetime.datetime(2023, 11, 14, tzinfo=datetime.timezone.utc),
             datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
-            datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2023, 11, 15, 12, 0, tzinfo=datetime.timezone.utc),
         ),
         # Test case 4: No executions in range
         (
@@ -552,12 +552,12 @@ def test_get_prev_error():
             datetime.datetime(2023, 12, 31, tzinfo=datetime.timezone.utc),
             datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
         ),
-        # Test case 11: Same start and end date that matches execution
+        # Test case 11: Same start and end date that matches execution (to_date is exclusive)
         (
             "0 12 15 * ? 2023",  # 15th of every month at 12:00 PM in 2023
             datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
             datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
-            datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc),
+            None,
         ),
         # Test case 12: Same start and end date that doesn't match execution
         (
@@ -566,7 +566,7 @@ def test_get_prev_error():
             datetime.datetime(2023, 12, 16, 12, 0, tzinfo=datetime.timezone.utc),
             None,
         ),
-        # Test case 13: Very short range
+        # Test case 13: Very short range (to_date is after execution, so execution is included)
         (
             "0 12 15 * ? 2023",  # 15th of every month at 12:00 PM in 2023
             datetime.datetime(2023, 12, 15, 11, 59, tzinfo=datetime.timezone.utc),


### PR DESCRIPTION
- Changed inclusive=True to inclusive=False in get_final_execution_time method
- Updated docstring to clarify that to_date is exclusive
- Updated method comments to explain exclusive behavior
- Updated 4 test cases to reflect the new exclusive behavior:
  * Test case 1: Changed expected result when to_date matches execution
  * Test case 3: Changed expected to previous execution when to_date is exclusive
  * Test case 11: Changed expected to None when from_date and to_date are same and match execution
  * Test case 13: Added clarifying comment
- Updated README documentation to explain exclusive end date behavior

This fix ensures that when to_date exactly matches a cron execution time, it will not be included in the result, only executions strictly before to_date will be returned. This aligns with expected behavior where to_date should be exclusive rather than inclusive.