### PR TITLE
Optimize cron parsing and occurrence lookup without API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ cython_debug/
 # VSCode settings
 .vscode/
 
+# Cursor settings
+.cursor/
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "aws-croniter"
-version = "1.0.5"
+version = "2.0.1"
 description = "A Python utility for AWS cron expressions. Validate and parse AWS EventBridge cron expressions seamlessly."
-authors = ["Siddarth Patil <siddarth3639@gmail.com>"]
+authors = ["Siddarth Patil <hello@techwithsid.com>"]
 license = "MIT"
 readme = "README.md"
 classifiers = [

--- a/src/aws_croniter/aws_croniter.py
+++ b/src/aws_croniter/aws_croniter.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 
 from aws_croniter.exceptions import AwsCroniterExpressionDayOfMonthError
 from aws_croniter.exceptions import AwsCroniterExpressionDayOfWeekError
@@ -64,13 +63,13 @@ class AwsCroniter:
         | Day-of-week  | 1-7 or SUN-SAT  | , - * ? L #   |
         | Year         | 1970-2199       | , - * /       |
         """
-        value_count = len(self.cron.split(" "))
+        value_count = len(self.rules)
         if value_count != 6:
             raise AwsCroniterExpressionError(
                 f"Incorrect number of values in '{self.cron}'. 6 required, {value_count} provided."
             )
 
-        minute, hour, day_of_month, month, day_of_week, year = self.cron.split(" ")
+        minute, hour, day_of_month, month, day_of_week, year = self.rules
 
         if not ((day_of_month == "?" and day_of_week != "?") or (day_of_month != "?" and day_of_week == "?")):
             raise AwsCroniterExpressionError(
@@ -78,17 +77,17 @@ class AwsCroniter:
                 "One must be a question mark (?)"
             )
 
-        if not re.fullmatch(RegexUtils.minute_regex(), minute):
+        if not RegexUtils.fullmatch_field("minute", RegexUtils.minute_regex, minute):
             raise AwsCroniterExpressionMinuteError(f"Invalid minute value '{minute}'.")
-        if not re.fullmatch(RegexUtils.hour_regex(), hour):
+        if not RegexUtils.fullmatch_field("hour", RegexUtils.hour_regex, hour):
             raise AwsCroniterExpressionHourError(f"Invalid hour value '{hour}'.")
-        if not re.fullmatch(RegexUtils.day_of_month_regex(), day_of_month):
+        if not RegexUtils.fullmatch_field("day_of_month", RegexUtils.day_of_month_regex, day_of_month):
             raise AwsCroniterExpressionDayOfMonthError(f"Invalid day-of-month value '{day_of_month}'.")
-        if not re.fullmatch(RegexUtils.month_regex(), month):
+        if not RegexUtils.fullmatch_field("month", RegexUtils.month_regex, month):
             raise AwsCroniterExpressionMonthError(f"Invalid month value '{month}'.")
-        if not re.fullmatch(RegexUtils.day_of_week_regex(), day_of_week):
+        if not RegexUtils.fullmatch_field("day_of_week", RegexUtils.day_of_week_regex, day_of_week):
             raise AwsCroniterExpressionDayOfWeekError(f"Invalid day-of-week value '{day_of_week}'.")
-        if not re.fullmatch(RegexUtils.year_regex(), year):
+        if not RegexUtils.fullmatch_field("year", RegexUtils.year_regex, year):
             raise AwsCroniterExpressionYearError(f"Invalid year value '{year}'.")
 
         # If validation passes, then parse the cron expression
@@ -126,7 +125,8 @@ class AwsCroniter:
         if rule.endswith("W"):
             return ["W", int(rule[0:-1])]
         if "#" in rule:
-            return ["#", int(rule.split("#")[0]), int(rule.split("#")[1])]
+            day_of_week, week_of_month = rule.split("#", 1)
+            return ["#", int(day_of_week), int(week_of_month)]
 
         allows = []
         for subrule in rule.split(","):
@@ -277,12 +277,12 @@ class AwsCroniter:
             # Using inclusive=False to make to_date exclusive - if to_date matches an execution,
             # it will not be included, and we'll get the previous execution instead
             occurrence = self.occurrence(to_date)
-            
+
             # Find the previous execution before to_date (to_date is exclusive)
             final_execution = occurrence.prev(inclusive=False)
-            
+
             # If no execution found, or the execution is before from_date, return None
             if final_execution is None or final_execution < from_date:
                 return None
-            
+
             return final_execution

--- a/src/aws_croniter/occurrence.py
+++ b/src/aws_croniter/occurrence.py
@@ -37,17 +37,15 @@ class Occurrence:
         current_hour = datetime_from.hour
         current_minute = datetime_from.minute
 
-        year = SequenceUtils.array_find_first(parsed.years, lambda c: c >= current_year)
+        year = SequenceUtils.find_first_gte(parsed.years, current_year)
         if year is None:
             return None
 
-        month = SequenceUtils.array_find_first(
-            parsed.months, lambda c: c >= (current_month if year == current_year else 1)
-        )
+        month = SequenceUtils.find_first_gte(parsed.months, current_month if year == current_year else 1)
         if not month:
             return self.__find_once(parsed, datetime.datetime(year + 1, 1, 1, tzinfo=datetime.timezone.utc))
 
-        is_same_month = True if year == current_year and month == current_month else False
+        is_same_month = year == current_year and month == current_month
         p_days_of_month = parsed.days_of_month
         is_w_in_current_month = None
 
@@ -64,22 +62,20 @@ class Occurrence:
         if is_w_in_current_month is not None and not is_w_in_current_month:
             day_of_month = False
         else:
-            day_of_month = SequenceUtils.array_find_first(
-                p_days_of_month, lambda c: c >= (current_day_of_month if is_same_month else 1)
-            )
+            day_of_month = SequenceUtils.find_first_gte(p_days_of_month, current_day_of_month if is_same_month else 1)
         if not day_of_month or not self.__is_valid_date(year, month, day_of_month):
             dt = datetime.datetime(year, month, 1, tzinfo=datetime.timezone.utc) + relativedelta(months=+1)
             return self.__find_once(parsed, dt)
 
         is_same_date = is_same_month and day_of_month == current_day_of_month
 
-        hour = SequenceUtils.array_find_first(parsed.hours, lambda c: c >= (current_hour if is_same_date else 0))
+        hour = SequenceUtils.find_first_gte(parsed.hours, current_hour if is_same_date else 0)
         if hour is None:
             dt = datetime.datetime(year, month, day_of_month, tzinfo=datetime.timezone.utc) + relativedelta(days=+1)
             return self.__find_once(parsed, dt)
 
-        minute = SequenceUtils.array_find_first(
-            parsed.minutes, lambda c: c >= (current_minute if is_same_date and hour == current_hour else 0)
+        minute = SequenceUtils.find_first_gte(
+            parsed.minutes, current_minute if is_same_date and hour == current_hour else 0
         )
         if minute is None:
             dt = datetime.datetime(year, month, day_of_month, hour, tzinfo=datetime.timezone.utc) + relativedelta(
@@ -103,18 +99,16 @@ class Occurrence:
         current_hour = datetime_from.hour
         current_minute = datetime_from.minute
 
-        year = SequenceUtils.array_find_last(parsed.years, lambda c: c <= current_year)
+        year = SequenceUtils.find_last_lte(parsed.years, current_year)
         if year is None:
             return None
 
-        month = SequenceUtils.array_find_last(
-            parsed.months, lambda c: c <= (current_month if year == current_year else 12)
-        )
+        month = SequenceUtils.find_last_lte(parsed.months, current_month if year == current_year else 12)
         if not month:
             dt = datetime.datetime(year, 1, 1, tzinfo=datetime.timezone.utc) + relativedelta(seconds=-1)
             return self.__find_prev_once(parsed, dt)
 
-        is_same_month = True if year == current_year and month == current_month else False
+        is_same_month = year == current_year and month == current_month
         p_days_of_month = parsed.days_of_month
         is_w_in_current_month = None
 
@@ -131,9 +125,7 @@ class Occurrence:
         if is_w_in_current_month is not None and not is_w_in_current_month:
             day_of_month = False
         else:
-            day_of_month = SequenceUtils.array_find_last(
-                p_days_of_month, lambda c: c <= (current_day_of_month if is_same_month else 31)
-            )
+            day_of_month = SequenceUtils.find_last_lte(p_days_of_month, current_day_of_month if is_same_month else 31)
 
         if not day_of_month or not self.__is_valid_date(year, month, day_of_month):
             dt = datetime.datetime(year, month, 1, tzinfo=datetime.timezone.utc) + relativedelta(seconds=-1)
@@ -141,13 +133,13 @@ class Occurrence:
 
         is_same_date = is_same_month and day_of_month == current_day_of_month
 
-        hour = SequenceUtils.array_find_last(parsed.hours, lambda c: c <= (current_hour if is_same_date else 23))
+        hour = SequenceUtils.find_last_lte(parsed.hours, current_hour if is_same_date else 23)
         if hour is None:
             dt = datetime.datetime(year, month, day_of_month, tzinfo=datetime.timezone.utc) + relativedelta(seconds=-1)
             return self.__find_prev_once(parsed, dt)
 
-        minute = SequenceUtils.array_find_last(
-            parsed.minutes, lambda c: c <= (current_minute if is_same_date and hour == current_hour else 59)
+        minute = SequenceUtils.find_last_lte(
+            parsed.minutes, current_minute if is_same_date and hour == current_hour else 59
         )
         if minute is None:
             dt = datetime.datetime(year, month, day_of_month, hour, tzinfo=datetime.timezone.utc) + relativedelta(

--- a/src/aws_croniter/utils.py
+++ b/src/aws_croniter/utils.py
@@ -1,10 +1,15 @@
+import bisect
 import calendar
 import datetime
+import re
+from typing import Callable
 
 from dateutil.relativedelta import relativedelta
 
 
 class RegexUtils:
+    _compiled_patterns: dict[str, re.Pattern[str]] = {}
+
     MINUTE_VALUES = r"(0?[0-9]|[1-5][0-9])"  # [0]0-59
     HOUR_VALUES = r"(0?[0-9]|1[0-9]|2[0-3])"  # [0]0-23
     MONTH_OF_DAY_VALUES = r"(0?[1-9]|[1-2][0-9]|3[0-1])"  # [0]1-31
@@ -69,6 +74,18 @@ class RegexUtils:
     def year_regex(cls):
         return rf"^({cls.common_regex(cls.YEAR_VALUES)})$"  # values , - * /
 
+    @classmethod
+    def _compiled_pattern(cls, name: str, pattern_builder: Callable[[], str]) -> re.Pattern[str]:
+        pattern = cls._compiled_patterns.get(name)
+        if pattern is None:
+            pattern = re.compile(pattern_builder())
+            cls._compiled_patterns[name] = pattern
+        return pattern
+
+    @classmethod
+    def fullmatch_field(cls, name: str, pattern_builder: Callable[[], str], value: str) -> bool:
+        return cls._compiled_pattern(name, pattern_builder).fullmatch(value) is not None
+
 
 class DateUtils:
     @staticmethod
@@ -80,24 +97,37 @@ class DateUtils:
     @staticmethod
     def get_days_of_month_from_days_of_week(year, month, days_of_week):
         """Get all days of the month that match the given days of the week."""
-        days_of_month = []
-        index = 0  # only for "#" use case
         no_of_days_in_month = calendar.monthrange(year, month)[1]
-        for i in range(1, no_of_days_in_month + 1, 1):
-            this_date = datetime.datetime(year, month, i, tzinfo=datetime.timezone.utc)
-            if days_of_week[0] == "L":
-                if days_of_week[1] == DateUtils.python_to_aws_day_of_week(this_date.weekday()):
+
+        if days_of_week[0] == "L":
+            target_dow = days_of_week[1]
+            for i in range(1, no_of_days_in_month + 1):
+                this_date = datetime.datetime(year, month, i, tzinfo=datetime.timezone.utc)
+                if target_dow == DateUtils.python_to_aws_day_of_week(this_date.weekday()):
                     same_day_next_week = datetime.datetime.fromtimestamp(
                         int(this_date.timestamp()) + 7 * 24 * 3600, tz=datetime.timezone.utc
                     )
                     if same_day_next_week.month != this_date.month:
                         return [i]
-            elif days_of_week[0] == "#":
-                if days_of_week[1] == DateUtils.python_to_aws_day_of_week(this_date.weekday()):
+            return []
+
+        if days_of_week[0] == "#":
+            target_dow = days_of_week[1]
+            target_week = days_of_week[2]
+            index = 0
+            for i in range(1, no_of_days_in_month + 1):
+                this_date = datetime.datetime(year, month, i, tzinfo=datetime.timezone.utc)
+                if target_dow == DateUtils.python_to_aws_day_of_week(this_date.weekday()):
                     index += 1
-                if days_of_week[2] == index:
-                    return [i]
-            elif DateUtils.python_to_aws_day_of_week(this_date.weekday()) in days_of_week:
+                    if target_week == index:
+                        return [i]
+            return []
+
+        days_of_month = []
+        allowed_days = frozenset(days_of_week)
+        for i in range(1, no_of_days_in_month + 1):
+            this_date = datetime.datetime(year, month, i, tzinfo=datetime.timezone.utc)
+            if DateUtils.python_to_aws_day_of_week(this_date.weekday()) in allowed_days:
                 days_of_month.append(i)
         return days_of_month
 
@@ -149,6 +179,22 @@ class TimeUtils:
 
 
 class SequenceUtils:
+    @staticmethod
+    def find_first_gte(sequence, value):
+        """Return the first element in a sorted sequence that is >= value."""
+        index = bisect.bisect_left(sequence, value)
+        if index < len(sequence):
+            return sequence[index]
+        return None
+
+    @staticmethod
+    def find_last_lte(sequence, value):
+        """Return the last element in a sorted sequence that is <= value."""
+        index = bisect.bisect_right(sequence, value) - 1
+        if index >= 0:
+            return sequence[index]
+        return None
+
     @staticmethod
     def array_find_first(sequence, function):
         """Find the first element in a sequence that satisfies the given function."""


### PR DESCRIPTION
## Summary

- Improve internal performance of AWS cron validation, parsing, and occurrence calculation while preserving existing behavior and public API.
- Target ~2× faster `AwsCroniter(...)` construction (cached compiled regex, fewer string splits) and ~1.2–1.4× faster next/prev/range operations (bisect on sorted field lists). Tested this locally on my Mac M1 Pro 32GB with Python 3.14
- No changes to tests or expected cron semantics; all 388 tests pass across Python 3.10–3.14.

## Changes

- **`aws_croniter.py`**: Reuse `self.rules` during validation; single `split("#", 1)` for `#` rules; validate via cached compiled regex patterns.
- **`utils.py`**: Add `RegexUtils.fullmatch_field()` with compile-once cache; add `SequenceUtils.find_first_gte` / `find_last_lte` using `bisect`; refactor `get_days_of_month_from_days_of_week` (hoist `L`/`#` branches, `frozenset` for weekday membership).
- **`occurrence.py`**: Use bisect helpers for sorted year/month/day/hour/minute lookups instead of linear scan with lambdas.

## Test plan

- [x] `poetry run tox` (py310–py314; coverage ≥ 80%)

## Notes

- **Behavior**: Intended to be identical for valid AWS EventBridge cron expressions; no new public methods or parameters.
- **Benchmarks** (local, approximate): ~2× construct; ~1.2–1.4× next/prev; ~1.25× `get_all_schedule_bw_dates` on heavy weekday range. Results vary by machine.