### PR TITLE
 Add cron schedule conflict detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ schedules programmatically.
     - [Fetch Previous Occurrence](#fetching-the-previous-occurrence)
     - [Fetch All Schedules in Range](#fetch-all-schedules-in-range)
     - [Get Final Execution Time](#get-final-execution-time)
+    - [Detect Schedule Conflicts](#detect-schedule-conflicts)
 5. [Contributing](#contributing)
 6. [License](#license)
 7. [Contact](#contact)
@@ -55,6 +56,7 @@ solution that also provides an improved and comprehensive tool for working with 
     - Next and previous occurrence times for a given schedule.
     - All occurrences of a schedule between two given dates.
     - Final execution time between two given dates (optimized for performance).
+    - Conflicts between two or more schedules inside a bounded UTC time window.
 - Handle special AWS cron syntax (e.g., `?`, `L`, `W`, `#`) and aliases for months (`JAN`, `FEB`, ...) and days of the
   week (`SUN`, `MON`, ...).
 
@@ -316,6 +318,145 @@ final_execution = aws_cron.get_final_execution_time(from_date, to_date)
 print(final_execution)
 # Output: datetime.datetime(2023, 12, 15, 12, 0, tzinfo=datetime.timezone.utc)
 ```
+
+---
+
+### **Detect Schedule Conflicts**
+
+Use `find_conflicts` with a list of **two or more** schedules. Each item may be a cron string or
+an `AwsCroniter` instance (already parsed). Passing only one expression raises `ValueError`.
+
+All datetimes must use `datetime.timezone.utc` (the package is not timezone-aware yet).
+
+**What counts as a conflict**
+
+Runs from **different** expressions that are closer than the minimum separation (`buffer`):
+
+| `buffer` | Meaning |
+|----------|---------|
+| `timedelta(0)` | Exact same run time only |
+| `timedelta(minutes=15)` | Runs within 15 minutes of each other |
+| `timedelta(hours=1)` | Runs within one hour of each other |
+
+`buffer` is a standard `timedelta` - seconds, minutes, hours, or combined units all work.
+Schedules are evaluated at **minute** precision (AWS cron has no seconds field).
+
+**Collection modes**
+
+| Mode | Behavior |
+|------|----------|
+| `ConflictCollectionMode.FIRST` (default) | Stop after the earliest conflict in the window |
+| `ConflictCollectionMode.ALL` | Collect up to `max_conflicts` conflicts, in time order |
+
+The search window `[from_date, to_date]` is inclusive. Work scales with occurrences examined in
+the window, not with the cartesian product of all schedule pairs.
+
+**Safety limits** (defaults shown) raise `AwsCroniterConflictSearchLimitError` when exceeded:
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `max_expressions` | `50` | Maximum schedules in one call |
+| `max_occurrences_per_expression` | `10_000` | Maximum runs generated per schedule |
+| `max_total_occurrences` | `100_000` | Maximum runs generated across all schedules |
+
+#### **First conflict with cron strings (default mode)**
+
+Pass raw cron strings and use the default collection mode to answer “do these two schedules
+clash, and when is the first clash?”
+
+```python
+from datetime import datetime, timedelta, timezone
+
+from aws_croniter import find_conflicts
+
+from_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+to_date = datetime(2024, 1, 31, 23, 59, tzinfo=timezone.utc)
+
+result = find_conflicts(
+    [
+        "0 12 15 * ? 2024",   # 12:00 on the 15th
+        "5 12 15 * ? 2024",   # 12:05 on the 15th
+    ],
+    from_date=from_date,
+    to_date=to_date,
+    buffer=timedelta(minutes=10),
+    # collection_mode defaults to ConflictCollectionMode.FIRST
+)
+
+if result.has_conflict:
+    conflict = result.first_conflict
+    print(conflict.separation)  # 0:05:00
+    for run in conflict.runs:
+        print(run.expression_index, run.expression, run.run_at)
+# Output (example):
+# 0:05:00
+# 0 0 12 15 * ? 2024 2024-01-15 12:00:00+00:00
+# 1 5 12 15 * ? 2024 2024-01-15 12:05:00+00:00
+```
+
+#### **Multiple conflicts with `AwsCroniter` objects (`ALL` mode)**
+
+Reuse parsed `AwsCroniter` instances (for example after validation elsewhere) and collect
+several conflicts across three or more schedules.
+
+```python
+from datetime import datetime, timedelta, timezone
+
+from aws_croniter import AwsCroniter, ConflictCollectionMode, find_conflicts
+
+from_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+to_date = datetime(2024, 1, 3, tzinfo=timezone.utc)
+
+schedules = [
+    AwsCroniter("*/15 * * * ? 2024"),  # every 15 minutes
+    AwsCroniter("*/10 * * * ? 2024"),  # every 10 minutes
+    AwsCroniter("0 12 15 * ? 2024"),   # once daily at noon on the 15th
+]
+
+result = find_conflicts(
+    schedules,
+    from_date=from_date,
+    to_date=to_date,
+    buffer=timedelta(0),  # exact timestamp collisions only
+    collection_mode=ConflictCollectionMode.ALL,
+    max_conflicts=3,
+)
+
+print(result.has_conflict, len(result.conflicts), result.occurrences_examined)
+for i, conflict in enumerate(result.conflicts, start=1):
+    print(f"Conflict {i} at {conflict.earliest}, separation={conflict.separation}")
+# Output (example):
+# True 3 13
+# Conflict 1 at 2024-01-01 00:00:00+00:00, separation=0:00:00
+# Conflict 2 at 2024-01-01 00:30:00+00:00, separation=0:00:00
+# Conflict 3 at 2024-01-01 01:00:00+00:00, separation=0:00:00
+```
+
+`*/15` and `*/10` align every 30 minutes (`00:00`, `00:30`, `01:00`, …), so `buffer=0` reports
+those exact collisions. Search stops after three conflicts, so `occurrences_examined` stays
+small even for dense schedules.
+
+#### **Reusable settings with `ConflictSearchOptions`**
+
+Pass keyword arguments directly, or bundle them once and reuse via `options`:
+
+```python
+from datetime import datetime, timezone
+
+from aws_croniter import ConflictSearchOptions, find_conflicts
+
+options = ConflictSearchOptions.from_call(
+    from_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    to_date=datetime(2024, 1, 31, tzinfo=timezone.utc),
+)
+
+result = find_conflicts(
+    ["0 12 15 * ? 2024", "0 13 15 * ? 2024"],
+    options=options,
+)
+```
+
+When `options` is provided, other keyword arguments to `find_conflicts` are ignored.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-croniter"
-version = "2.0.1"
+version = "2.1.0"
 description = "A Python utility for AWS cron expressions. Validate and parse AWS EventBridge cron expressions seamlessly."
 authors = ["Siddarth Patil <hello@techwithsid.com>"]
 license = "MIT"

--- a/src/aws_croniter/__init__.py
+++ b/src/aws_croniter/__init__.py
@@ -1,4 +1,20 @@
 from .aws_croniter import AwsCroniter
+from .conflict_models import ConflictCollectionMode
+from .conflict_models import ConflictSearchOptions
+from .conflict_models import ConflictSearchResult
+from .conflict_models import ScheduleConflict
+from .conflict_models import ScheduledRun
+from .conflicts import find_conflicts
+from .exceptions import AwsCroniterConflictSearchLimitError
 
 # Should be exported when using `from aws_croniter import *`
-__all__ = ["AwsCroniter"]
+__all__ = [
+    "AwsCroniter",
+    "AwsCroniterConflictSearchLimitError",
+    "ConflictCollectionMode",
+    "ConflictSearchOptions",
+    "ConflictSearchResult",
+    "ScheduleConflict",
+    "ScheduledRun",
+    "find_conflicts",
+]

--- a/src/aws_croniter/aws_croniter.py
+++ b/src/aws_croniter/aws_croniter.py
@@ -216,7 +216,7 @@ class AwsCroniter:
         :return: list of datetime objects
         """
 
-        if type(from_date) != type(to_date) and not (
+        if type(from_date) is not type(to_date) and not (
             isinstance(from_date, type(to_date)) or isinstance(to_date, type(from_date))
         ):
             raise ValueError(
@@ -259,7 +259,7 @@ class AwsCroniter:
         :param to_date: datetime object to where the schedule will end with tzinfo in utc (exclusive).
         :return: datetime object representing the final execution time, or None if no executions found
         """
-        if type(from_date) != type(to_date) and not (
+        if type(from_date) is not type(to_date) and not (
             isinstance(from_date, type(to_date)) or isinstance(to_date, type(from_date))
         ):
             raise ValueError(

--- a/src/aws_croniter/conflict_models.py
+++ b/src/aws_croniter/conflict_models.py
@@ -1,0 +1,126 @@
+import datetime
+from dataclasses import dataclass
+from dataclasses import field
+from enum import Enum
+
+
+class ConflictCollectionMode(Enum):
+    """How many schedule conflicts to collect before stopping."""
+
+    FIRST = "first"
+    ALL = "all"
+
+
+@dataclass(frozen=True)
+class ScheduledRun:
+    """One scheduled execution time attributed to a source expression."""
+
+    expression_index: int
+    expression: str
+    run_at: datetime.datetime
+
+
+@dataclass(frozen=True)
+class ScheduleConflict:
+    """Runs from different expressions that violate the minimum separation (buffer)."""
+
+    runs: tuple[ScheduledRun, ...]
+    separation: datetime.timedelta
+
+    @property
+    def earliest(self) -> datetime.datetime:
+        return min(run.run_at for run in self.runs)
+
+    @property
+    def latest(self) -> datetime.datetime:
+        return max(run.run_at for run in self.runs)
+
+
+@dataclass
+class ConflictSearchOptions:
+    """
+    Configuration for schedule conflict detection.
+
+    All datetimes must use ``datetime.timezone.utc``. The search window is
+    inclusive on both ends: occurrences at ``from_date`` or ``to_date`` are considered.
+    """
+
+    from_date: datetime.datetime
+    to_date: datetime.datetime
+    buffer: datetime.timedelta = field(default_factory=lambda: datetime.timedelta(0))
+    collection_mode: ConflictCollectionMode = ConflictCollectionMode.FIRST
+    max_conflicts: int = 1
+    max_expressions: int = 50
+    max_occurrences_per_expression: int = 10_000
+    max_total_occurrences: int = 100_000
+
+    def __post_init__(self) -> None:
+        _validate_utc(self.from_date, "from_date")
+        _validate_utc(self.to_date, "to_date")
+        if self.buffer < datetime.timedelta(0):
+            raise ValueError("buffer must be greater than or equal to zero")
+        if self.from_date > self.to_date:
+            raise ValueError("from_date must be less than or equal to to_date")
+        if self.max_conflicts < 1:
+            raise ValueError("max_conflicts must be at least 1")
+        if self.max_expressions < 2:
+            raise ValueError("max_expressions must be at least 2")
+        if self.max_occurrences_per_expression < 1:
+            raise ValueError("max_occurrences_per_expression must be at least 1")
+        if self.max_total_occurrences < 1:
+            raise ValueError("max_total_occurrences must be at least 1")
+
+    @property
+    def stop_on_first(self) -> bool:
+        return self.collection_mode is ConflictCollectionMode.FIRST
+
+    def effective_max_conflicts(self) -> int:
+        if self.collection_mode is ConflictCollectionMode.FIRST:
+            return 1
+        return self.max_conflicts
+
+    @classmethod
+    def from_call(
+        cls,
+        *,
+        from_date: datetime.datetime,
+        to_date: datetime.datetime,
+        buffer: datetime.timedelta | None = None,
+        collection_mode: ConflictCollectionMode = ConflictCollectionMode.FIRST,
+        max_conflicts: int = 1,
+        max_expressions: int = 50,
+        max_occurrences_per_expression: int = 10_000,
+        max_total_occurrences: int = 100_000,
+    ) -> "ConflictSearchOptions":
+        if buffer is None:
+            buffer = datetime.timedelta(0)
+        return cls(
+            from_date=from_date,
+            to_date=to_date,
+            buffer=buffer,
+            collection_mode=collection_mode,
+            max_conflicts=max_conflicts,
+            max_expressions=max_expressions,
+            max_occurrences_per_expression=max_occurrences_per_expression,
+            max_total_occurrences=max_total_occurrences,
+        )
+
+
+@dataclass
+class ConflictSearchResult:
+    """Outcome of a conflict search over one or more cron expressions."""
+
+    has_conflict: bool
+    conflicts: list[ScheduleConflict] = field(default_factory=list)
+    occurrences_examined: int = 0
+
+    @property
+    def first_conflict(self) -> ScheduleConflict | None:
+        if not self.conflicts:
+            return None
+        return self.conflicts[0]
+
+
+def _validate_utc(value: datetime.datetime, name: str) -> None:
+    if value.tzinfo is None or value.tzinfo != datetime.timezone.utc:
+        raise ValueError(f"{name} must be a datetime with tzinfo=datetime.timezone.utc")

--- a/src/aws_croniter/conflicts.py
+++ b/src/aws_croniter/conflicts.py
@@ -1,0 +1,169 @@
+import datetime
+import heapq
+from collections import deque
+from collections.abc import Sequence
+from typing import Union
+
+from aws_croniter.aws_croniter import AwsCroniter
+from aws_croniter.conflict_models import ConflictCollectionMode
+from aws_croniter.conflict_models import ConflictSearchOptions
+from aws_croniter.conflict_models import ConflictSearchResult
+from aws_croniter.conflict_models import ScheduleConflict
+from aws_croniter.conflict_models import ScheduledRun
+from aws_croniter.exceptions import AwsCroniterConflictSearchLimitError
+from aws_croniter.occurrence_stream import OccurrenceCounter
+from aws_croniter.occurrence_stream import OccurrenceStream
+
+CronInput = Union[str, AwsCroniter]
+
+
+def find_conflicts(
+    expressions: Sequence[CronInput],
+    *,
+    from_date: datetime.datetime | None = None,
+    to_date: datetime.datetime | None = None,
+    options: ConflictSearchOptions | None = None,
+    buffer: datetime.timedelta | None = None,
+    collection_mode: ConflictCollectionMode = ConflictCollectionMode.FIRST,
+    max_conflicts: int = 1,
+    max_expressions: int = 50,
+    max_occurrences_per_expression: int = 10_000,
+    max_total_occurrences: int = 100_000,
+) -> ConflictSearchResult:
+    """
+    Find schedule conflicts across two or more AWS cron expressions.
+
+    Pass ``from_date``/``to_date`` (and optional keywords), or a pre-built
+    ``ConflictSearchOptions`` as ``options`` (keywords are then ignored).
+
+    A conflict is when runs from different expressions fall within ``buffer`` of
+    each other (``buffer=0`` requires the exact same timestamp).
+    """
+    if options is None:
+        if from_date is None or to_date is None:
+            raise ValueError("from_date and to_date are required when options is not provided")
+        options = ConflictSearchOptions.from_call(
+            from_date=from_date,
+            to_date=to_date,
+            buffer=buffer,
+            collection_mode=collection_mode,
+            max_conflicts=max_conflicts,
+            max_expressions=max_expressions,
+            max_occurrences_per_expression=max_occurrences_per_expression,
+            max_total_occurrences=max_total_occurrences,
+        )
+
+    cron_pairs = _prepare_expressions(expressions, options.max_expressions)
+    return _search_conflicts(cron_pairs, options)
+
+
+def _prepare_expressions(
+    expressions: Sequence[CronInput],
+    max_expressions: int,
+) -> list[tuple[AwsCroniter, str]]:
+    expression_count = len(expressions)
+    if expression_count == 0:
+        raise ValueError("at least two cron expressions are required; none were provided")
+    if expression_count == 1:
+        raise ValueError("at least two cron expressions are required; only one was provided")
+    if expression_count > max_expressions:
+        raise AwsCroniterConflictSearchLimitError(
+            f"Expression count {expression_count} exceeds max_expressions ({max_expressions})."
+        )
+
+    prepared: list[tuple[AwsCroniter, str]] = []
+    for item in expressions:
+        if isinstance(item, AwsCroniter):
+            prepared.append((item, item.cron))
+        else:
+            prepared.append((AwsCroniter(item), item))
+    return prepared
+
+
+def _search_conflicts(
+    cron_pairs: list[tuple[AwsCroniter, str]],
+    options: ConflictSearchOptions,
+) -> ConflictSearchResult:
+    counter = OccurrenceCounter(options.max_total_occurrences)
+    streams = [
+        OccurrenceStream(
+            cron,
+            expression,
+            index,
+            options.from_date,
+            options.to_date,
+            options.max_occurrences_per_expression,
+            counter,
+        )
+        for index, (cron, expression) in enumerate(cron_pairs)
+    ]
+
+    heap: list[tuple[datetime.datetime, int, OccurrenceStream]] = []
+    for stream in streams:
+        next_time = stream.peek()
+        if next_time is not None:
+            heapq.heappush(heap, (next_time, stream.expression_index, stream))
+
+    recent: deque[ScheduledRun] = deque()
+    conflicts: list[ScheduleConflict] = []
+    target = options.effective_max_conflicts()
+
+    while heap:
+        run_at, _, stream = heapq.heappop(heap)
+        run = ScheduledRun(stream.expression_index, stream.expression, run_at)
+
+        _prune_recent(recent, run_at, options.buffer)
+        conflict = _conflict_with_recent(run, recent, options.buffer)
+        if conflict is not None:
+            conflicts.append(conflict)
+            if len(conflicts) >= target:
+                return ConflictSearchResult(True, conflicts, counter.total)
+
+        recent.append(run)
+        stream.pop()
+        next_time = stream.peek()
+        if next_time is not None:
+            heapq.heappush(heap, (next_time, stream.expression_index, stream))
+
+    return ConflictSearchResult(bool(conflicts), conflicts, counter.total)
+
+
+def _prune_recent(recent: deque[ScheduledRun], current_time: datetime.datetime, buffer: datetime.timedelta) -> None:
+    threshold = current_time - buffer
+    while recent and recent[0].run_at < threshold:
+        recent.popleft()
+
+
+def _conflict_with_recent(
+    current: ScheduledRun,
+    recent: deque[ScheduledRun],
+    buffer: datetime.timedelta,
+) -> ScheduleConflict | None:
+    conflicting = [
+        prior
+        for prior in recent
+        if prior.expression_index != current.expression_index
+        and abs(current.run_at - prior.run_at) <= buffer
+    ]
+    if not conflicting:
+        return None
+
+    runs = _dedupe_runs([current, *conflicting])
+    if len(runs) < 2:
+        return None
+
+    separation = min(
+        abs(a.run_at - b.run_at) for i, a in enumerate(runs) for b in runs[i + 1 :]
+    )
+    return ScheduleConflict(tuple(runs), separation)
+
+
+def _dedupe_runs(runs: list[ScheduledRun]) -> list[ScheduledRun]:
+    seen: set[tuple[int, datetime.datetime]] = set()
+    unique: list[ScheduledRun] = []
+    for run in sorted(runs, key=lambda item: (item.run_at, item.expression_index)):
+        key = (run.expression_index, run.run_at)
+        if key not in seen:
+            seen.add(key)
+            unique.append(run)
+    return unique

--- a/src/aws_croniter/exceptions.py
+++ b/src/aws_croniter/exceptions.py
@@ -38,3 +38,9 @@ class AwsCroniterExpressionDayOfWeekError(AwsCroniterExpressionError):
     """Exception raised for invalid day-of-week values in an AWS cron expression."""
 
     pass
+
+
+class AwsCroniterConflictSearchLimitError(AwsCroniterExpressionError):
+    """Raised when conflict detection exceeds configured safety limits."""
+
+    pass

--- a/src/aws_croniter/occurrence_stream.py
+++ b/src/aws_croniter/occurrence_stream.py
@@ -1,0 +1,78 @@
+import datetime
+from collections.abc import Iterator
+
+from aws_croniter.aws_croniter import AwsCroniter
+from aws_croniter.exceptions import AwsCroniterConflictSearchLimitError
+
+
+class OccurrenceCounter:
+    """Tracks generated occurrences across all streams for a conflict search."""
+
+    def __init__(self, max_total_occurrences: int) -> None:
+        self.max_total_occurrences = max_total_occurrences
+        self.total = 0
+
+    def record(self) -> None:
+        self.total += 1
+        if self.total > self.max_total_occurrences:
+            raise AwsCroniterConflictSearchLimitError(f"Exceeded max_total_occurrences ({self.max_total_occurrences}).")
+
+
+class OccurrenceStream:
+    """Lazily yields ascending UTC occurrence times within a bounded window."""
+
+    def __init__(
+        self,
+        cron: "AwsCroniter",
+        expression: str,
+        expression_index: int,
+        from_date: datetime.datetime,
+        to_date: datetime.datetime,
+        max_occurrences: int,
+        counter: OccurrenceCounter,
+    ) -> None:
+        self._cron = cron
+        self.expression = expression
+        self.expression_index = expression_index
+        self._to_date = to_date.replace(second=0, microsecond=0)
+        self._max_occurrences = max_occurrences
+        self._counter = counter
+        self._count = 0
+        self._exhausted = False
+        self._cursor = from_date.replace(second=0, microsecond=0) - datetime.timedelta(seconds=1)
+        self._next: datetime.datetime | None = None
+        self._advance()
+
+    def peek(self) -> datetime.datetime | None:
+        return self._next
+
+    def pop(self) -> datetime.datetime:
+        if self._next is None:
+            raise StopIteration
+        current = self._next
+        self._advance()
+        return current
+
+    def _advance(self) -> None:
+        self._next = None
+        if self._exhausted:
+            return
+        while True:
+            if self._count >= self._max_occurrences:
+                raise AwsCroniterConflictSearchLimitError(
+                    f"Exceeded max_occurrences_per_expression ({self._max_occurrences}) "
+                    f"for expression index {self.expression_index}."
+                )
+            candidate = self._cron.occurrence(self._cursor).next()
+            if candidate is None or candidate > self._to_date:
+                self._exhausted = True
+                return
+            self._cursor = candidate
+            self._count += 1
+            self._counter.record()
+            self._next = candidate
+            return
+
+    def __iter__(self) -> Iterator[datetime.datetime]:
+        while self._next is not None:
+            yield self.pop()

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,0 +1,175 @@
+import datetime
+
+import pytest
+
+from aws_croniter import ConflictCollectionMode
+from aws_croniter import ConflictSearchOptions
+from aws_croniter import find_conflicts
+from aws_croniter.aws_croniter import AwsCroniter
+from aws_croniter.exceptions import AwsCroniterConflictSearchLimitError
+from aws_croniter.exceptions import AwsCroniterExpressionError
+
+UTC = datetime.timezone.utc
+FROM_DATE = datetime.datetime(2024, 1, 1, tzinfo=UTC)
+TO_DATE = datetime.datetime(2024, 1, 31, 23, 59, tzinfo=UTC)
+DENSE_RANGE_END = datetime.datetime(2024, 1, 2, tzinfo=UTC)
+
+EXPR_SAME_DAY_NOON = "0 12 15 * ? 2024"
+EXPR_SAME_DAY_NOON_PLUS_5 = "5 12 15 * ? 2024"
+EXPR_SAME_DAY_1H15_LATER = "15 13 15 * ? 2024"
+EXPR_SAME_DAY_1H_LATER = "0 13 15 * ? 2024"
+EXPR_DENSE_EVERY_15 = "*/15 * * * ? 2024"
+EXPR_DENSE_EVERY_10 = "*/10 * * * ? 2024"
+
+
+def _pair(expr_a: str, expr_b: str, input_type: str) -> list:
+    if input_type == "strings":
+        return [expr_a, expr_b]
+    if input_type == "croniter":
+        return [AwsCroniter(expr_a), AwsCroniter(expr_b)]
+    return [expr_a, AwsCroniter(expr_b)]
+
+
+@pytest.mark.parametrize("input_type", ["strings", "croniter", "mixed"])
+def test_exact_collision_with_string_or_croniter_inputs(input_type):
+    expr_a = EXPR_SAME_DAY_NOON
+    expr_b = EXPR_SAME_DAY_NOON
+    result = find_conflicts(_pair(expr_a, expr_b, input_type), from_date=FROM_DATE, to_date=TO_DATE)
+
+    assert result.has_conflict is True
+    assert len(result.conflicts) == 1
+    conflict = result.first_conflict
+    assert conflict.separation == datetime.timedelta(0)
+    assert {run.run_at for run in conflict.runs} == {datetime.datetime(2024, 1, 15, 12, 0, tzinfo=UTC)}
+    assert {run.expression for run in conflict.runs} == {expr_a, expr_b}
+
+
+@pytest.mark.parametrize(
+    "second_expression,buffer,expected_has_conflict,expected_separation",
+    [
+        (EXPR_SAME_DAY_NOON_PLUS_5, datetime.timedelta(minutes=10), True, datetime.timedelta(minutes=5)),
+        (
+            EXPR_SAME_DAY_1H15_LATER,
+            datetime.timedelta(hours=1, minutes=30),
+            True,
+            datetime.timedelta(hours=1, minutes=15),
+        ),
+        (EXPR_SAME_DAY_1H15_LATER, datetime.timedelta(hours=1), False, None),
+        (EXPR_SAME_DAY_NOON_PLUS_5, datetime.timedelta(minutes=4), False, None),
+    ],
+    ids=["minutes_within_buffer", "hours_and_minutes_within_buffer", "hours_outside_buffer", "minutes_outside_buffer"],
+)
+def test_buffer_with_minutes_or_combined_hours_and_minutes(
+    second_expression, buffer, expected_has_conflict, expected_separation
+):
+    result = find_conflicts(
+        [EXPR_SAME_DAY_NOON, second_expression],
+        from_date=FROM_DATE,
+        to_date=TO_DATE,
+        buffer=buffer,
+    )
+
+    assert result.has_conflict is expected_has_conflict
+    if expected_has_conflict:
+        assert result.first_conflict.separation == expected_separation
+    else:
+        assert result.conflicts == []
+
+
+@pytest.mark.parametrize(
+    "collection_mode,max_conflicts,expected_conflict_count",
+    [
+        (ConflictCollectionMode.FIRST, 1, 1),
+        (ConflictCollectionMode.ALL, 3, 3),
+    ],
+)
+def test_collection_mode_first_stops_early_and_all_collects_multiple(
+    collection_mode, max_conflicts, expected_conflict_count
+):
+    result = find_conflicts(
+        [EXPR_DENSE_EVERY_15, EXPR_DENSE_EVERY_10],
+        from_date=FROM_DATE,
+        to_date=DENSE_RANGE_END,
+        buffer=datetime.timedelta(0),
+        collection_mode=collection_mode,
+        max_conflicts=max_conflicts,
+    )
+
+    assert result.has_conflict is True
+    assert len(result.conflicts) == expected_conflict_count
+    if collection_mode is ConflictCollectionMode.ALL:
+        assert len({conflict.earliest for conflict in result.conflicts}) == expected_conflict_count
+        assert all(conflict.separation == datetime.timedelta(0) for conflict in result.conflicts)
+
+
+def test_sparse_schedules_report_no_conflict():
+    result = find_conflicts(
+        ["0 9 1 * ? 2024", "0 9 2 * ? 2024"],
+        from_date=FROM_DATE,
+        to_date=TO_DATE,
+    )
+
+    assert result.has_conflict is False
+    assert result.conflicts == []
+
+
+def test_invalid_expression_raises():
+    with pytest.raises(AwsCroniterExpressionError):
+        find_conflicts(["invalid cron", EXPR_SAME_DAY_NOON], from_date=FROM_DATE, to_date=TO_DATE)
+
+
+@pytest.mark.parametrize(
+    "expressions,match",
+    [
+        ([EXPR_SAME_DAY_NOON], "only one was provided"),
+        ([], "none were provided"),
+    ],
+)
+def test_rejects_too_few_expressions(expressions, match):
+    with pytest.raises(ValueError, match=match):
+        find_conflicts(expressions, from_date=FROM_DATE, to_date=TO_DATE)
+
+
+def test_requires_utc_datetimes():
+    with pytest.raises(ValueError, match="tzinfo"):
+        find_conflicts(
+            [EXPR_SAME_DAY_NOON, EXPR_SAME_DAY_1H_LATER],
+            from_date=datetime.datetime(2024, 1, 1),
+            to_date=TO_DATE,
+        )
+
+
+def test_max_expressions_limit():
+    expressions = [f"0 {hour} 15 * ? 2024" for hour in range(5)]
+    with pytest.raises(AwsCroniterConflictSearchLimitError, match="max_expressions"):
+        find_conflicts(expressions, from_date=FROM_DATE, to_date=TO_DATE, max_expressions=3)
+
+
+def test_max_total_occurrences_limit():
+    with pytest.raises(AwsCroniterConflictSearchLimitError, match="max_total_occurrences"):
+        find_conflicts(
+            ["* * * * ? 2024", "30 * * * ? 2024"],
+            from_date=FROM_DATE,
+            to_date=datetime.datetime(2024, 1, 1, 6, 0, tzinfo=UTC),
+            buffer=datetime.timedelta(0),
+            max_total_occurrences=5,
+        )
+
+
+def test_conflict_search_options_object():
+    options = ConflictSearchOptions.from_call(
+        from_date=FROM_DATE,
+        to_date=DENSE_RANGE_END,
+        buffer=datetime.timedelta(0),
+        collection_mode=ConflictCollectionMode.ALL,
+        max_conflicts=2,
+    )
+    result = find_conflicts([EXPR_DENSE_EVERY_15, EXPR_DENSE_EVERY_10], options=options)
+
+    assert result.has_conflict is True
+    assert len(result.conflicts) == 2
+
+
+def test_from_date_after_to_date_rejected():
+    with pytest.raises(ValueError, match="from_date must be"):
+        ConflictSearchOptions(from_date=TO_DATE, to_date=FROM_DATE)


### PR DESCRIPTION
## Summary
- Add `find_conflicts` to detect when two or more AWS/EventBridge cron schedules run too close together (configurable `buffer`, default exact match only).
- Return structured results (`ConflictSearchResult`, `ScheduleConflict`, `ScheduledRun`) with support for `FIRST` vs `ALL` collection modes and reusable `ConflictSearchOptions`.
- Use lazy occurrence streams and min-heap merge (linear in occurrences examined); enforce safety caps (`max_expressions`, `max_occurrences_per_expression`, `max_total_occurrences`).
- Fixes issue #19 

## Changes
- New modules: `conflicts.py`, `conflict_models.py`, `occurrence_stream.py`
- New exception: `AwsCroniterConflictSearchLimitError`
- Public exports on `aws_croniter` package
- README section with examples (cron strings, `AwsCroniter` objects, `ALL` mode, options object, safety limit defaults)
- Parameterized tests in `tests/test_conflicts.py`
- Version bump to `2.1.0`

## Test plan
- [x] `poetry run pytest tests/` (406 tests passing)
- [x] Conflict tests cover buffer (minutes and hours+minutes), collection modes, string/`AwsCroniter`/mixed inputs, validation, and safety limits

## Notes
- UTC-only; no timezone support in this PR (by design).
- Conflicts are **pairwise** across different expressions (any 2 of N within buffer); all N need not align at once.
- Pairwise detection uses a single k-way merge path for 2+ expressions.